### PR TITLE
Add milestone lifecycle management with recurring materialization and overdue detection

### DIFF
--- a/tools/hq/internal/cmd/milestones.go
+++ b/tools/hq/internal/cmd/milestones.go
@@ -36,6 +36,12 @@ func runMilestonesList(basePath string, args []string) int {
 	}
 
 	now := time.Now()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+
+	if err := parser.MaterializeRecurring(basePath, now); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
+	}
+
 	milestones, err := parser.LoadMilestones(basePath, now)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -43,13 +49,18 @@ func runMilestonesList(basePath string, args []string) int {
 	}
 
 	if !showAll {
-		open := milestones[:0]
+		filtered := milestones[:0]
 		for _, m := range milestones {
-			if !m.Checked {
-				open = append(open, m)
+			if m.HasDate {
+				if m.Checked && m.Date.Before(today) {
+					continue
+				}
+			} else if m.Checked {
+				continue
 			}
+			filtered = append(filtered, m)
 		}
-		milestones = open
+		milestones = filtered
 	}
 
 	if jsonOut {
@@ -79,18 +90,16 @@ func runMilestonesList(basePath string, args []string) int {
 		if m.Checked {
 			mark = "x"
 		}
-		prefix := ""
-		if m.Recurring {
-			prefix = m.RecurringRule + " "
-		}
 		dateStr := ""
-		if m.HasDate {
+		if m.Overdue {
+			dateStr = fmt.Sprintf("! %s (%d日超過) ", m.Date.Format("2006-01-02"), -m.RemainingDays)
+		} else if m.HasDate {
 			dateStr = m.Date.Format("2006-01-02") + " "
 			if !m.Checked {
 				dateStr += fmt.Sprintf("(%dd) ", m.RemainingDays)
 			}
 		}
-		fmt.Printf("  %3d. [%s] %s%s%s\n", m.Line, mark, prefix, dateStr, m.Content)
+		fmt.Printf("  %3d. [%s] %s%s\n", m.Line, mark, dateStr, m.Content)
 	}
 	return 0
 }

--- a/tools/hq/internal/model/types.go
+++ b/tools/hq/internal/model/types.go
@@ -10,6 +10,7 @@ type Milestone struct {
 	Done          int       `json:"done"`
 	Total         int       `json:"total"`
 	Checked       bool      `json:"checked"`
+	Overdue       bool      `json:"overdue"`
 	HasDate       bool      `json:"has_date"`
 	Recurring     bool      `json:"recurring"`
 	RecurringRule string    `json:"recurring_rule"` // "@monthly 10", "@month-end", etc.

--- a/tools/hq/internal/parser/milestones.go
+++ b/tools/hq/internal/parser/milestones.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -24,6 +25,14 @@ var (
 	milestoneUndatedRegex = regexp.MustCompile(`^- \[([ xX])\] (.+)$`)
 )
 
+// Template regexes — checkbox-less recurring rules.
+var (
+	templateMonthlyRegex  = regexp.MustCompile(`^- @monthly (\d{1,2}) (.+)$`)
+	templateMonthEndRegex = regexp.MustCompile(`^- @month-end (.+)$`)
+	templateYearlyRegex   = regexp.MustCompile(`^- @yearly (\d{2}-\d{2}) (.+)$`)
+	templateWeeklyRegex   = regexp.MustCompile(`(?i)^- @weekly (mon|tue|wed|thu|fri|sat|sun) (.+)$`)
+)
+
 // ParseMilestones parses milestone entries from markdown content.
 // Iterates over all lines (including frontmatter) to track accurate line numbers.
 func ParseMilestones(content string, filePath string, now time.Time) []model.Milestone {
@@ -41,14 +50,12 @@ func ParseMilestones(content string, filePath string, now time.Time) []model.Mil
 			date, err := time.ParseInLocation("2006-01-02", m[2], now.Location())
 			if err == nil {
 				remaining := int(date.Sub(today).Hours() / 24)
-				if remaining < 0 {
-					remaining = 0
-				}
 				milestones = append(milestones, model.Milestone{
 					Content:       m[3],
 					Date:          date,
 					RemainingDays: remaining,
 					Checked:       checked,
+					Overdue:       !checked && remaining < 0,
 					HasDate:       true,
 					FilePath:      filePath,
 					Line:          lineNum,
@@ -181,7 +188,9 @@ func LoadMilestones(basePath string, now time.Time) ([]model.Milestone, error) {
 		}
 		return nil, err
 	}
-	return ParseMilestones(string(data), path, now), nil
+	milestones := ParseMilestones(string(data), path, now)
+	SortMilestones(milestones)
+	return milestones, nil
 }
 
 // ToggleMilestone toggles a milestone checkbox at the given line in the file.
@@ -204,4 +213,137 @@ func AddMilestone(filePath string, text string) error {
 	}
 	content += fmt.Sprintf("- [ ] %s\n", text)
 	return os.WriteFile(filePath, []byte(content), 0644)
+}
+
+// SortMilestones sorts milestones: overdue first (date asc), then upcoming dated (date asc), then undated (file order).
+func SortMilestones(milestones []model.Milestone) {
+	sort.SliceStable(milestones, func(i, j int) bool {
+		mi, mj := milestones[i], milestones[j]
+		ci, cj := milestoneCategory(mi), milestoneCategory(mj)
+		if ci != cj {
+			return ci < cj
+		}
+		if mi.HasDate && mj.HasDate {
+			return mi.Date.Before(mj.Date)
+		}
+		return false
+	})
+}
+
+// milestoneCategory returns sort priority: 0=overdue, 1=dated, 2=undated.
+func milestoneCategory(m model.Milestone) int {
+	if m.Overdue {
+		return 0
+	}
+	if m.HasDate {
+		return 1
+	}
+	return 2
+}
+
+// recurringTemplate represents a checkbox-less recurring rule.
+type recurringTemplate struct {
+	ruleType string // "monthly", "month-end", "yearly", "weekly"
+	param    string // day number, "", "MM-DD", weekday
+	content  string
+}
+
+// ParseRecurringTemplates extracts checkbox-less recurring templates from content.
+func ParseRecurringTemplates(content string) []recurringTemplate {
+	var templates []recurringTemplate
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if m := templateMonthlyRegex.FindStringSubmatch(trimmed); m != nil {
+			day := atoi(m[1])
+			if day >= 1 && day <= 31 {
+				templates = append(templates, recurringTemplate{
+					ruleType: "monthly", param: m[1], content: m[2],
+				})
+			}
+		} else if m := templateMonthEndRegex.FindStringSubmatch(trimmed); m != nil {
+			templates = append(templates, recurringTemplate{
+				ruleType: "month-end", content: m[1],
+			})
+		} else if m := templateYearlyRegex.FindStringSubmatch(trimmed); m != nil {
+			parts := strings.Split(m[1], "-")
+			month, day := atoi(parts[0]), atoi(parts[1])
+			if month >= 1 && month <= 12 && day >= 1 && day <= 31 {
+				templates = append(templates, recurringTemplate{
+					ruleType: "yearly", param: m[1], content: m[2],
+				})
+			}
+		} else if m := templateWeeklyRegex.FindStringSubmatch(trimmed); m != nil {
+			templates = append(templates, recurringTemplate{
+				ruleType: "weekly", param: strings.ToLower(m[1]), content: m[2],
+			})
+		}
+	}
+	return templates
+}
+
+// templateNextDate computes the next occurrence date for a recurring template.
+func templateNextDate(tmpl recurringTemplate, today time.Time) time.Time {
+	switch tmpl.ruleType {
+	case "monthly":
+		return nextMonthly(atoi(tmpl.param), today)
+	case "month-end":
+		return nextMonthEnd(today)
+	case "yearly":
+		return nextYearly(tmpl.param, today)
+	case "weekly":
+		return nextWeekly(tmpl.param, today)
+	default:
+		return today
+	}
+}
+
+// MaterializeRecurring reads _milestones.md, generates concrete dated instances
+// from recurring templates, and appends any missing instances to the file.
+func MaterializeRecurring(basePath string, now time.Time) error {
+	path := MilestoneFilePath(basePath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	content := string(data)
+
+	templates := ParseRecurringTemplates(content)
+	if len(templates) == 0 {
+		return nil
+	}
+
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+
+	// Collect existing dated lines for deduplication
+	existing := make(map[string]bool)
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if m := milestoneDatedRegex.FindStringSubmatch(trimmed); m != nil {
+			existing[m[2]+" "+m[3]] = true
+		}
+	}
+
+	var toAppend []string
+	for _, tmpl := range templates {
+		date := templateNextDate(tmpl, today)
+		dateStr := date.Format("2006-01-02")
+		key := dateStr + " " + tmpl.content
+		if !existing[key] {
+			toAppend = append(toAppend, fmt.Sprintf("- [ ] %s %s", dateStr, tmpl.content))
+			existing[key] = true
+		}
+	}
+
+	if len(toAppend) == 0 {
+		return nil
+	}
+
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += strings.Join(toAppend, "\n") + "\n"
+	return os.WriteFile(path, []byte(content), 0644)
 }

--- a/tools/hq/internal/parser/milestones_test.go
+++ b/tools/hq/internal/parser/milestones_test.go
@@ -1,6 +1,9 @@
 package parser
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -32,6 +35,9 @@ purpose: "test"
 	if ms.RemainingDays != 8 {
 		t.Errorf("expected 8 remaining days, got %d", ms.RemainingDays)
 	}
+	if ms.Overdue {
+		t.Error("expected overdue=false for future milestone")
+	}
 	if ms.FilePath != "test/milestones.md" {
 		t.Errorf("unexpected file path: %q", ms.FilePath)
 	}
@@ -43,11 +49,48 @@ purpose: "test"
 	if !ms2.Checked {
 		t.Error("expected checked")
 	}
-	if ms2.RemainingDays != 0 {
-		t.Errorf("expected 0 remaining days for past milestone, got %d", ms2.RemainingDays)
+	if ms2.RemainingDays >= 0 {
+		t.Errorf("expected negative remaining days for past milestone, got %d", ms2.RemainingDays)
+	}
+	if ms2.Overdue {
+		t.Error("expected overdue=false for checked past milestone")
 	}
 	if ms2.Line != 7 {
 		t.Errorf("expected line 7, got %d", ms2.Line)
+	}
+}
+
+func TestParseMilestones_Overdue(t *testing.T) {
+	content := `- [ ] 2026-03-01 overdue task
+- [x] 2026-03-01 done past task
+- [ ] 2026-03-10 upcoming task
+`
+	now := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+	milestones := ParseMilestones(content, "test.md", now)
+
+	if len(milestones) != 3 {
+		t.Fatalf("expected 3 milestones, got %d", len(milestones))
+	}
+
+	// Overdue unchecked
+	if !milestones[0].Overdue {
+		t.Error("expected overdue=true for unchecked past milestone")
+	}
+	if milestones[0].RemainingDays != -4 {
+		t.Errorf("expected -4 remaining days, got %d", milestones[0].RemainingDays)
+	}
+
+	// Checked past — not overdue
+	if milestones[1].Overdue {
+		t.Error("expected overdue=false for checked past milestone")
+	}
+
+	// Future — not overdue
+	if milestones[2].Overdue {
+		t.Error("expected overdue=false for future milestone")
+	}
+	if milestones[2].RemainingDays != 5 {
+		t.Errorf("expected 5 remaining days, got %d", milestones[2].RemainingDays)
 	}
 }
 
@@ -418,5 +461,241 @@ func TestNextWeeklyWrapAround(t *testing.T) {
 	expected := time.Date(2026, 3, 9, 0, 0, 0, 0, time.UTC)
 	if !date.Equal(expected) {
 		t.Errorf("expected %v, got %v", expected, date)
+	}
+}
+
+// --- Template parsing tests ---
+
+func TestParseRecurringTemplates(t *testing.T) {
+	content := `---
+title: milestones
+---
+
+- @monthly 10 保険期限
+- @month-end 請求処理
+- @yearly 03-15 確定申告
+- @weekly mon ミーティング
+- [ ] 2026-03-05 リリース
+- [ ] undated task
+`
+	templates := ParseRecurringTemplates(content)
+	if len(templates) != 4 {
+		t.Fatalf("expected 4 templates, got %d", len(templates))
+	}
+
+	if templates[0].ruleType != "monthly" || templates[0].param != "10" || templates[0].content != "保険期限" {
+		t.Errorf("unexpected template 0: %+v", templates[0])
+	}
+	if templates[1].ruleType != "month-end" || templates[1].content != "請求処理" {
+		t.Errorf("unexpected template 1: %+v", templates[1])
+	}
+	if templates[2].ruleType != "yearly" || templates[2].param != "03-15" || templates[2].content != "確定申告" {
+		t.Errorf("unexpected template 2: %+v", templates[2])
+	}
+	if templates[3].ruleType != "weekly" || templates[3].param != "mon" || templates[3].content != "ミーティング" {
+		t.Errorf("unexpected template 3: %+v", templates[3])
+	}
+}
+
+func TestParseRecurringTemplates_NoCheckboxLinesOnly(t *testing.T) {
+	content := `- [ ] @monthly 10 checkbox monthly
+- @monthly 10 template monthly
+`
+	templates := ParseRecurringTemplates(content)
+	if len(templates) != 1 {
+		t.Fatalf("expected 1 template (checkbox-less only), got %d", len(templates))
+	}
+	if templates[0].content != "template monthly" {
+		t.Errorf("unexpected content: %q", templates[0].content)
+	}
+}
+
+func TestParseRecurringTemplates_InvalidSkipped(t *testing.T) {
+	content := `- @monthly 0 invalid day
+- @monthly 32 invalid day
+- @yearly 13-15 invalid month
+`
+	templates := ParseRecurringTemplates(content)
+	if len(templates) != 0 {
+		t.Fatalf("expected 0 templates for invalid rules, got %d", len(templates))
+	}
+}
+
+// --- Materialization tests ---
+
+func TestMaterializeRecurring(t *testing.T) {
+	dir := t.TempDir()
+	projDir := filepath.Join(dir, "projects")
+	if err := os.MkdirAll(projDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	initial := `---
+title: milestones
+---
+
+- @monthly 10 保険期限
+- [ ] 2026-03-05 リリース
+`
+	msFile := filepath.Join(projDir, "_milestones.md")
+	if err := os.WriteFile(msFile, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	if err := MaterializeRecurring(dir, now); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(msFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+
+	// Should have appended "- [ ] 2026-03-10 保険期限"
+	if !strings.Contains(content, "- [ ] 2026-03-10 保険期限") {
+		t.Errorf("expected materialized milestone, got:\n%s", content)
+	}
+
+	// Original content preserved
+	if !strings.Contains(content, "- @monthly 10 保険期限") {
+		t.Error("template should be preserved")
+	}
+	if !strings.Contains(content, "- [ ] 2026-03-05 リリース") {
+		t.Error("existing milestone should be preserved")
+	}
+}
+
+func TestMaterializeRecurring_NoDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	projDir := filepath.Join(dir, "projects")
+	if err := os.MkdirAll(projDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// File already has the materialized instance
+	initial := `- @monthly 10 保険期限
+- [ ] 2026-03-10 保険期限
+`
+	msFile := filepath.Join(projDir, "_milestones.md")
+	if err := os.WriteFile(msFile, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	if err := MaterializeRecurring(dir, now); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(msFile)
+	// Should not duplicate
+	count := strings.Count(string(data), "- [ ] 2026-03-10 保険期限")
+	if count != 1 {
+		t.Errorf("expected 1 instance, found %d in:\n%s", count, string(data))
+	}
+}
+
+func TestMaterializeRecurring_CheckedInstanceCountsAsExisting(t *testing.T) {
+	dir := t.TempDir()
+	projDir := filepath.Join(dir, "projects")
+	if err := os.MkdirAll(projDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Checked instance already exists
+	initial := `- @monthly 10 保険期限
+- [x] 2026-03-10 保険期限
+`
+	msFile := filepath.Join(projDir, "_milestones.md")
+	if err := os.WriteFile(msFile, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	if err := MaterializeRecurring(dir, now); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(msFile)
+	// Should not add another instance
+	if strings.Contains(string(data), "- [ ] 2026-03-10 保険期限") {
+		t.Errorf("should not add unchecked instance when checked one exists:\n%s", string(data))
+	}
+}
+
+func TestMaterializeRecurring_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	// No milestones file — should not error
+	if err := MaterializeRecurring(dir, time.Now()); err != nil {
+		t.Errorf("expected nil error for missing file, got %v", err)
+	}
+}
+
+// --- Sort tests ---
+
+func TestSortMilestones(t *testing.T) {
+	content := `- [ ] undated task
+- [ ] 2026-03-10 upcoming
+- [ ] 2026-03-01 overdue
+- [x] 2026-02-15 done past
+- [ ] 2026-03-15 later
+`
+	now := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+	milestones := ParseMilestones(content, "test.md", now)
+	SortMilestones(milestones)
+
+	// Expected order: overdue(03-01), dated by date asc(02-15, 03-10, 03-15), undated
+	if len(milestones) != 5 {
+		t.Fatalf("expected 5, got %d", len(milestones))
+	}
+	expected := []string{"overdue", "done past", "upcoming", "later", "undated task"}
+	for i, e := range expected {
+		if milestones[i].Content != e {
+			t.Errorf("milestones[%d] = %q, want %q", i, milestones[i].Content, e)
+		}
+	}
+}
+
+// --- Visibility rules tests ---
+
+func TestVisibilityRules(t *testing.T) {
+	content := `- [ ] 2026-03-10 future unchecked
+- [x] 2026-03-10 future checked
+- [ ] 2026-03-01 overdue unchecked
+- [x] 2026-03-01 past checked
+- [ ] undated unchecked
+- [x] undated checked
+`
+	now := time.Date(2026, 3, 5, 0, 0, 0, 0, time.UTC)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	milestones := ParseMilestones(content, "test.md", now)
+
+	// Apply the same visibility rules as the CLI
+	var visible []string
+	for _, m := range milestones {
+		if m.HasDate {
+			if m.Checked && m.Date.Before(today) {
+				continue
+			}
+		} else if m.Checked {
+			continue
+		}
+		visible = append(visible, m.Content)
+	}
+
+	expected := []string{
+		"future unchecked",
+		"future checked",
+		"overdue unchecked",
+		"undated unchecked",
+	}
+	if len(visible) != len(expected) {
+		t.Fatalf("expected %d visible, got %d: %v", len(expected), len(visible), visible)
+	}
+	for i, e := range expected {
+		if visible[i] != e {
+			t.Errorf("visible[%d] = %q, want %q", i, visible[i], e)
+		}
 	}
 }

--- a/tools/hq/internal/ui/app.go
+++ b/tools/hq/internal/ui/app.go
@@ -86,7 +86,9 @@ type wordTickMsg struct{}
 
 func loadDataCmd(basePath string, taskFiles []parser.TaskFileRole) tea.Cmd {
 	return func() tea.Msg {
-		data, err := parser.LoadAll(basePath, time.Now(), taskFiles)
+		now := time.Now()
+		_ = parser.MaterializeRecurring(basePath, now)
+		data, err := parser.LoadAll(basePath, now, taskFiles)
 		return dataLoadedMsg{data: data, err: err}
 	}
 }
@@ -212,13 +214,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if item, ok := a.dashboard.currentMilestoneItem(); ok {
 					if item.isAddRow {
 						return a, a.startAddItem(SectionMilestones, item.filePath, "YYYY-MM-DD description...")
-					}
-					// Block toggle for recurring milestones
-					if item.milestoneIdx >= 0 && item.milestoneIdx < len(a.dashboard.Data.Milestones) {
-						ms := a.dashboard.Data.Milestones[item.milestoneIdx]
-						if ms.Recurring {
-							return a, nil
-						}
 					}
 					// Toggle existing milestone
 					if item.filePath != "" && item.line > 0 {

--- a/tools/hq/internal/ui/dashboard.go
+++ b/tools/hq/internal/ui/dashboard.go
@@ -82,19 +82,24 @@ func (dv *DashboardView) ScrollDown() {
 		}
 		if next < len(items) {
 			dv.TodoCursor = next
+			return
 		}
-		return
 	case SectionMilestones:
 		items := dv.buildMilestoneItems()
 		if dv.MilestoneCursor < len(items)-1 {
 			dv.MilestoneCursor++
+			return
 		}
-		return
+	default:
+		m := dv.maxScroll(dv.FocusSection)
+		if dv.ScrollOffset[dv.FocusSection] < m {
+			dv.ScrollOffset[dv.FocusSection]++
+			return
+		}
 	}
-	max := dv.maxScroll(dv.FocusSection)
-	if dv.ScrollOffset[dv.FocusSection] < max {
-		dv.ScrollOffset[dv.FocusSection]++
-	}
+	// At boundary — move to next section
+	dv.NextSection()
+	dv.enterSectionTop()
 }
 
 func (dv *DashboardView) ScrollUp() {
@@ -108,16 +113,54 @@ func (dv *DashboardView) ScrollUp() {
 		}
 		if prev >= 0 {
 			dv.TodoCursor = prev
+			return
 		}
-		return
 	case SectionMilestones:
 		if dv.MilestoneCursor > 0 {
 			dv.MilestoneCursor--
+			return
 		}
-		return
+	default:
+		if dv.ScrollOffset[dv.FocusSection] > 0 {
+			dv.ScrollOffset[dv.FocusSection]--
+			return
+		}
 	}
-	if dv.ScrollOffset[dv.FocusSection] > 0 {
-		dv.ScrollOffset[dv.FocusSection]--
+	// At boundary — move to prev section
+	dv.PrevSection()
+	dv.enterSectionBottom()
+}
+
+// enterSectionTop sets the cursor/scroll to the first item when entering a section from above.
+func (dv *DashboardView) enterSectionTop() {
+	switch dv.FocusSection {
+	case SectionMilestones:
+		dv.MilestoneCursor = 0
+	case SectionTodo:
+		items := dv.buildTodoItems()
+		dv.TodoCursor = 0
+		for dv.TodoCursor < len(items) && items[dv.TodoCursor].isSeparator {
+			dv.TodoCursor++
+		}
+	default:
+		dv.ScrollOffset[dv.FocusSection] = 0
+	}
+}
+
+// enterSectionBottom sets the cursor/scroll to the last item when entering a section from below.
+func (dv *DashboardView) enterSectionBottom() {
+	switch dv.FocusSection {
+	case SectionMilestones:
+		items := dv.buildMilestoneItems()
+		dv.MilestoneCursor = len(items) - 1
+	case SectionTodo:
+		items := dv.buildTodoItems()
+		dv.TodoCursor = len(items) - 1
+		for dv.TodoCursor > 0 && items[dv.TodoCursor].isSeparator {
+			dv.TodoCursor--
+		}
+	default:
+		dv.ScrollOffset[dv.FocusSection] = dv.maxScroll(dv.FocusSection)
 	}
 }
 

--- a/tools/hq/internal/ui/dashboard.go
+++ b/tools/hq/internal/ui/dashboard.go
@@ -174,8 +174,12 @@ type milestoneItem struct {
 func (dv *DashboardView) buildMilestoneItems() []milestoneItem {
 	var items []milestoneItem
 	for i, ms := range dv.Data.Milestones {
-		// Hide recurring milestones more than 10 days away
-		if ms.Recurring && ms.RemainingDays > 10 {
+		// Visibility: hide checked past items and checked undated items
+		if ms.HasDate {
+			if ms.Checked && ms.RemainingDays < 0 {
+				continue
+			}
+		} else if ms.Checked {
 			continue
 		}
 		items = append(items, milestoneItem{
@@ -427,13 +431,14 @@ func (dv *DashboardView) renderMilestones(width int) string {
 				check = "[x]"
 			}
 			var line string
-			if ms.HasDate {
-				var indicator string
-				if ms.Recurring {
-					indicator = recurringIndicatorStyle.Render("@")
-				} else {
-					indicator = MilestoneUrgencyIndicator(ms.RemainingDays)
-				}
+			if ms.Overdue {
+				indicator := warningIndicatorStyle.Render("⚠")
+				dateStr := ms.Date.Format("01-02")
+				overdue := fmt.Sprintf("(%d日超過)", -ms.RemainingDays)
+				content := truncateToWidth(ms.Content, width-30)
+				line = fmt.Sprintf("%s %s %s  %s %s", check, indicator, content, dateStr, overdue)
+			} else if ms.HasDate {
+				indicator := MilestoneUrgencyIndicator(ms.RemainingDays)
 				dateStr := ms.Date.Format("01-02")
 				remaining := fmt.Sprintf("(残り%d日)", ms.RemainingDays)
 				content := truncateToWidth(ms.Content, width-30)

--- a/tools/hq/internal/ui/styles.go
+++ b/tools/hq/internal/ui/styles.go
@@ -129,12 +129,14 @@ func clientStyle(index int) lipgloss.Style {
 // MilestoneUrgencyIndicator returns a colored indicator based on remaining days.
 func MilestoneUrgencyIndicator(days int) string {
 	switch {
-	case days <= 7:
+	case days <= 0:
 		return urgencyRedStyle.Render("●")
-	case days <= 14:
+	case days <= 3:
 		return urgencyYellowStyle.Render("●")
-	default:
+	case days <= 7:
 		return urgencyGreenStyle.Render("●")
+	default:
+		return lipgloss.NewStyle().Foreground(colorSubtle).Render("●")
 	}
 }
 

--- a/tools/hq/internal/ui/styles.go
+++ b/tools/hq/internal/ui/styles.go
@@ -103,6 +103,10 @@ var (
 				Foreground(colorAccent).
 				Bold(true)
 
+	warningIndicatorStyle = lipgloss.NewStyle().
+				Foreground(colorYellow).
+				Bold(true)
+
 	modalBorderStyle = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
 				BorderForeground(colorAccent).


### PR DESCRIPTION
## Summary

マイルストーンのライフサイクル管理を導入。チェックボックスなしの繰り返しルール（`- @monthly 10 ...`）をテンプレートとして扱い、具体的な日付付きインスタンス（`- [ ] 2026-03-10 ...`）を自動生成する。期限超過の未完了マイルストーンを検出・表示し、セクション間の上下キーナビゲーションも追加。

## Changes

- テンプレート→インスタンスモデルの導入: チェックボックスなし `@monthly`/`@month-end`/`@yearly`/`@weekly` 行をテンプレートとしてパースし、`MaterializeRecurring()` で日付付きインスタンスを自動生成・重複排除
- 期限超過（overdue）検出: `Overdue` フィールド追加、`RemainingDays` の負値を許容、CLI/TUI で警告表示（⚠マーク、超過日数表示）
- ソート順の改善: 期限超過 → 日付付き（日付昇順） → 日付なし
- 表示ルールの変更: 完了済み＋期限切れのみ非表示、完了済み＋未来日付は表示継続
- 緊急度バッジの閾値調整: 0日=赤、3日=黄、7日=緑、それ以上=グレー
- セクション間ナビゲーション: 上下キーでセクション境界を超えて移動可能に
- テスト追加: テンプレートパース、マテリアライゼーション、overdue、ソート、表示ルールの11テスト追加（計47テスト）