### PR TITLE
fix: split pr skill overrides into formal vs invariant rules

### DIFF
--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -231,20 +231,17 @@ bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-cache-push.sh" <plan>
 
 ### Create the PR
 
-Delegate to the `pr` skill with the prepared body:
+Delegate to the `pr` skill, passing:
 
-```bash
-gh pr create \
-  --title "<type>: <description>" \
-  --body "<prepared body>" \
-  --label "hq:pr" \
-  [--milestone "<inherited>"] \
-  [--project "<inherited>" ...]
-```
+- The **prepared body** assembled above (Summary + `## Changes` + optional `## Manual Verification` + optional `## Known Issues` + `Closes #<plan>` / `Refs #<task>` trailer).
+- The derived **title**: `<type>: <description>` (plan title with the `(plan)` scope removed).
+- The **list of unchecked `[manual]` items** (already embedded in `## Manual Verification`).
+- The **list of escalated FB entries** (already embedded in `## Known Issues`).
+- **Milestone and project(s)** inherited from the `hq:task` (read from `.hq/tasks/<branch-dir>/gh/task.json`).
 
-- Title: derive from the plan title (`<type>(plan): ...` → `<type>: ...`).
-- Always apply the `hq:pr` label (create it lazily per workflow rule if missing).
-- Inherit milestone and projects from the `hq:task`.
+The `pr` skill is the single path to `gh pr create`. Do not call `gh pr create` directly from this command — delegation keeps the skill's invariant enforcement (Known Issues, FB atomic move, `Closes` / `Refs` trailer, `hq:pr` label, milestone / project inheritance) on one path.
+
+**Override interaction**: if the project has a `.hq/pr.md`, the `pr` skill applies it only within its allowed override scope (see `plugin/v2/skills/pr/SKILL.md` § Project Overrides). In the `/hq:start` invocation mode the prepared body above is treated as immutable by the skill — `.hq/pr.md` cannot alter, reorder, or strip the prepared body assembled in this phase. Overrides may influence only the title line.
 
 ## Phase 8: Report
 

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -23,7 +23,7 @@
 - **`hq:plan`** — a GitHub Issue (label: `hq:plan`) that describes **how** to do it. The implementation plan. **Center** of the workflow — drives execution, verification, and PR. One `hq:task` can have multiple `hq:plan` issues.
 - **`hq:feedback`** — a GitHub Issue (label: `hq:feedback`) for unresolved problems carved out from a PR's Known Issues during PR review. Created via `/hq:triage` only.
 - **`hq:doc`** — a GitHub Issue (label: `hq:doc`) for informational notes / research findings worth preserving (not a direct task). Created manually by the user when investigation turns up something useful to retain. Not consumed by any workflow command.
-- **`hq:pr`** — a PR label applied automatically by `/hq:start` when the PR is created. Marks a PR as a product of the `hq:plan` → PR workflow. Useful for filtering PRs that belong to this workflow vs ad-hoc PRs.
+- **`hq:pr`** — a PR label applied automatically by the `pr` skill (in either invocation mode — Standalone `/pr` or via `/hq:start`). Marks a PR as a product of the `hq:plan` → PR workflow. Useful for filtering PRs that belong to this workflow vs ad-hoc PRs.
 - **`hq:wip`** — a GitHub Issue modifier label. Purpose is twofold: (1) **drafting marker** — the issue is still being shaped and not ready for automation, (2) **automation gate** — when `/hq:start` or `/hq:draft` is triggered automatically (e.g., from GitHub Actions), the command must skip (or, in manual invocation, pause and confirm) any Issue carrying this label.
 
 These are plugin-specific terms. Always use the `hq:` prefix to distinguish from general "task", "plan", or "feedback".
@@ -208,6 +208,19 @@ Refs #<hq:task>
 
 During PR review, use `/hq:triage <PR>` to process the `Known Issues` entries — each can be: (1) added to the `hq:plan` for follow-up work, (2) left as-is, or (3) carved out as an `hq:feedback` Issue.
 
+### Invariants (NOT overridable by `.hq/pr.md`)
+
+The following structural elements of the PR body are invariants of the HQ workflow. A project's `.hq/pr.md` (consumed by the `pr` skill) MAY customize prose style, language, title conventions, and optional sections — but it MUST NOT suppress, rename, reformat, or otherwise alter any item below:
+
+- **`## Manual Verification` section presence** — whenever unchecked `[manual]` items exist in the plan's `## Acceptance` section at PR creation time, they MUST appear verbatim under a section literally named `## Manual Verification`.
+- **`## Known Issues` section presence** — whenever pending FB files exist at PR creation time, their titles + brief descriptions MUST appear under a section literally named `## Known Issues`.
+- **FB atomic move to `feedbacks/done/`** — any FB file whose content is surfaced in `## Known Issues` MUST be moved to `feedbacks/done/` as part of the same PR-creation operation. Surfacing without moving (or moving without surfacing) is forbidden.
+- **`Closes #<hq:plan>` / `Refs #<hq:task>` trailer** — every PR body MUST end with these two lines.
+- **`hq:pr` label** — every PR created by the `pr` skill (in either invocation mode — Standalone or via `/hq:start`) MUST carry the `hq:pr` label.
+- **Milestone / project inheritance** — if the source `hq:task` has a milestone or project(s), the PR MUST inherit them via `--milestone` / `--project` flags.
+
+A newly bootstrapped repository should understand these rules from this section alone — `.hq/pr.md` overrides are applied on top, never in place of, the invariants above.
+
 ## Verification Pipeline
 
 Run the following checks when validating work on a branch — whether completing an `hq:plan`, preparing a PR, or reviewing ad-hoc changes. Focus is not required; all checks operate on the git diff.
@@ -269,5 +282,7 @@ Skills that perform verification or review may output feedback files (FB) to `.h
 - When an FB item is **escalated to the PR body's `## Known Issues`** during `/hq:start` Phase 7, move its file to `feedbacks/done/` as well — its role has shifted to the PR body (now the source of truth for residual problems)
 - Maximum **2 rounds** of the fix → re-verify cycle. After 2 rounds, escalate the remainder to the PR body and move those FB files to `done/`.
 - Do not modify or delete FB files — only move resolved/escalated ones to `done/`
+
+**Atomicity** — escalation into `## Known Issues` and the move to `feedbacks/done/` are a single atomic operation. Surfacing an FB in the PR body without moving its file (or moving the file without surfacing the content) is forbidden. This atomicity cannot be skipped or weakened by project-level overrides such as `.hq/pr.md` — see `## PR Body Structure` § Invariants.
 
 **Note**: FB escalation to `hq:feedback` Issues happens during PR review via `/hq:triage` — not from `/hq:start`, `/pr`, or `/hq:archive`. Local FB files are a **branch-internal** concept; the PR body's `## Known Issues` is the hand-off point.

--- a/plugin/v2/skills/pr/SKILL.md
+++ b/plugin/v2/skills/pr/SKILL.md
@@ -7,7 +7,37 @@ description: Create a pull request for the current branch
 
 - Overrides: !`cat .hq/pr.md 2>/dev/null || echo "none"`
 
-If `.hq/pr.md` exists, its instructions take precedence over the defaults below (e.g., PR body format, language, title conventions). Apply overrides on top of this skill's base flow.
+If `.hq/pr.md` exists, its instructions are applied **only within the allowed override scope** defined below. The Invariants list below is fixed by the HQ workflow and cannot be overridden by `.hq/pr.md` or any project-level configuration — it applies to every PR this skill creates.
+
+### Override scope (allowed)
+
+Projects MAY use `.hq/pr.md` to customize:
+
+- PR body prose style inside `## Summary`, `## Changes`, `## Notes` (tone, level of detail, bullet vs paragraph)
+- Natural language used in those prose sections
+- Title-line conventions (prefix style, length cap, wording)
+- Ordering of **optional** sections (`## Notes` placement relative to other optional sections)
+- Additional **project-specific optional sections** that do not conflict with the Invariants
+
+### Invariants (NOT overridable)
+
+The following are invariants of the HQ workflow. `.hq/pr.md` MUST NOT suppress, rename, reformat, or otherwise alter these — they must appear in every PR this skill creates whenever their triggering condition is met:
+
+- **`## Manual Verification` section** — when unchecked `[manual]` items exist in the plan's `## Acceptance` section at PR creation time, they MUST be listed verbatim under a section literally named `## Manual Verification`.
+- **`## Known Issues` section** — when pending FB files exist at PR creation time, their titles + brief descriptions MUST be listed under a section literally named `## Known Issues`.
+- **FB atomic move to `feedbacks/done/`** — any FB file whose content is surfaced in `## Known Issues` MUST be moved to `feedbacks/done/` as part of the same PR-creation operation. Surfacing without moving (or moving without surfacing) is forbidden.
+- **`Closes #<plan>` / `Refs #<task>` trailer** — every PR body MUST end with these two lines, pointing at the driving `hq:plan` and source `hq:task`.
+- **`hq:pr` label** — every PR created by this skill MUST carry the `hq:pr` label.
+- **Milestone / project inheritance** — if the source `hq:task` has a milestone or project(s), the PR MUST inherit them via `--milestone` / `--project` flags.
+
+If `.hq/pr.md` content appears to contradict any Invariant, the Invariant wins. Flag the conflict to the user after PR creation so the override file can be corrected.
+
+### Invocation mode
+
+This skill has two modes. `.hq/pr.md` overrides apply differently in each:
+
+- **Standalone** (user invokes `/pr` directly): the skill composes the full PR body from git + session context. `.hq/pr.md` overrides apply to the allowed scope above during composition. Invariants are still enforced.
+- **From `/hq:start`** (Phase 7 delegation): the caller has already assembled the PR body, including `## Manual Verification` and `## Known Issues` sections and the `Closes/Refs` trailer. The prepared body is treated as **immutable** — `.hq/pr.md` may influence **only** the title line; it MUST NOT rewrite, reformat, or strip any section of the prepared body. The skill's role in this mode is execution (push branch, call `gh pr create` with the right flags), not composition.
 
 ## Context
 
@@ -21,6 +51,13 @@ If `.hq/pr.md` exists, its instructions take precedence over the defaults below 
 
 ## Instructions
 
+### Mode detection (do this first)
+
+Before running any step below, determine invocation mode:
+
+- **From `/hq:start`** — the caller passes a fully prepared PR body, title, and milestone/project flags. In this mode, **skip Steps 4 and 5 entirely** (body composition is already done). Execute Steps 1, 2, 3, 6, 7, 8, 9 using the caller-provided body verbatim. `.hq/pr.md` overrides MAY influence only the title line; the prepared body is immutable. See `## Project Overrides` § Invocation mode.
+- **Standalone** — invoked directly (user typed `/pr`, no prepared body available). Execute all steps. Compose the body in Step 5 per the template below, applying `.hq/pr.md` overrides within the allowed scope and enforcing the Invariants.
+
 1. **Check preconditions**:
    - If there are uncommitted changes, warn the user and ask whether to proceed or commit first
    - If there are no commits ahead of the base branch, abort — nothing to PR
@@ -31,15 +68,15 @@ If `.hq/pr.md` exists, its instructions take precedence over the defaults below 
 
 3. **Resolve traceability** — read `.hq/tasks/<branch-dir>/context.md` (branch name: `/` → `-`). Extract `plan`, `source`, and `branch` fields. If not found, check your memory for focus info. If neither exists, ask the user for the `hq:plan` and `hq:task` issue numbers.
 
-4. **Compose PR body sections from upstream context**:
+4. **(Standalone mode only)** **Compose PR body sections from local state**:
 
-   - **`## Manual Verification`** — when invoked as part of `/hq:start`, the caller provides the list of unchecked `[manual]` items from the plan's `## Acceptance` section. Include them verbatim. When invoked standalone, skip this section if no `[manual]` items are available.
+   - **`## Manual Verification`** — read the plan body from `.hq/tasks/<branch-dir>/gh/plan.md` and extract unchecked `[manual]` items from its `## Acceptance` section. If any exist, include them verbatim. If none, omit this section.
 
-   - **`## Known Issues`** — when invoked as part of `/hq:start`, the caller provides the list of unresolved FB files to escalate into the PR body. Each entry should include the FB title and a brief description. When invoked standalone, check `.hq/tasks/<branch-dir>/feedbacks/` (pending only, not `done/`): if any exist, include them here.
+   - **`## Known Issues`** — check `.hq/tasks/<branch-dir>/feedbacks/` (pending only, not `done/`). For each FB file, include its title and a brief description. If none, omit this section.
 
    **FB files that are surfaced in `## Known Issues` MUST be moved to `feedbacks/done/`** as part of PR creation — the PR body becomes the source of truth for residual issues. Do NOT create `hq:feedback` Issues from this skill. Escalation to `hq:feedback` happens later via `/hq:triage` during PR review.
 
-5. **Draft the PR** based on the context above AND session context (what you know about why these changes were made):
+5. **(Standalone mode only)** **Draft the PR** based on the context above AND session context (what you know about why these changes were made):
    - **Title**: derive from the `hq:plan` title. Format: `<type>: <description>` (remove the `(plan)` scope from the `hq:plan` title). Keep under 70 characters.
    - **Body** in this format:
 
@@ -96,3 +133,4 @@ If `.hq/pr.md` exists, its instructions take precedence over the defaults below 
 - Keep the summary focused — details go in the Changes section.
 - **No `hq:feedback` creation** — this skill does NOT create `hq:feedback` Issues. Residual problems flow to the PR body's `## Known Issues` section, to be triaged later via `/hq:triage`.
 - **FB escalation is atomic** — if an FB file's content appears in the PR body, the file MUST be moved to `feedbacks/done/`.
+- **Invariants are not overridable** — see `## Project Overrides` § Invariants. `.hq/pr.md` cannot override the `## Manual Verification` or `## Known Issues` sections, the FB atomic move, the `Closes #<plan>` / `Refs #<task>` trailer, the `hq:pr` label, or milestone / project inheritance. In `/hq:start` invocation mode, the prepared body is immutable and overrides apply only to the title line.


### PR DESCRIPTION
## Summary

`.hq/pr.md` の override 宣言が曖昧で、ワークフロー不変ルール（Known Issues、FB escalation atomicity、Closes/Refs、hq:pr ラベル、milestone/project 継承）まで上書きされうる問題を修正。override の適用範囲を形式系に限定し、不変ルールを明文化することで、`.hq/pr.md` 利用プロジェクトで atomicity 保証が暗黙に崩れるリスクを解消した。

## Changes

- `plugin/v2/skills/pr/SKILL.md` の Project Overrides を「Override scope (allowed)」「Invariants (NOT overridable)」「Invocation mode」の3サブセクションに分離
- pr skill Instructions 冒頭に Mode detection を追加し、Steps 4-5 を Standalone mode 専用として明示（`/hq:start` 経由時は body 再合成をスキップ）
- `plugin/v2/commands/start.md` Phase 7 のインライン `gh pr create` 例を削除し、pr skill への delegation に一本化。override interaction 注記を追加
- `plugin/v2/skills/bootstrap/templates/workflow.md` と `.claude/rules/workflow.local.md` に Invariants callout と atomicity 強化文言を追加。`hq:pr` ラベルの Terminology 定義も両 invocation mode に対応
- Invariants に `## Manual Verification` を追加（従来 override scope / invariants どちらにも分類されていなかった）

## Notes

- out of scope: `plugin/v2/docs/workflow.md` L16 の `hq:pr` ラベル記述は依然 `/hq:start` narrow scope のまま。本 PR のスコープ外（Terminology 本体は更新済み）。
- 他 skill（`code-review`, `security-scan`, `e2e-web`）も同じ "take precedence over the defaults below" 構文を持つが、atomicity 不変ルールは PR 特有のため今回は触らず。必要なら別 task で検討。

## Manual Verification

- [ ] [manual] `pr/SKILL.md` の新しい "Invariants" リストが曖昧でない：空でない `.hq/pr.md` を持つ読者が、項目ごとに override 可能か固定かを判別でき、グレーゾーンがない
- [ ] [manual] `start.md` Phase 7 の指示が単一の delegation 経路として読める（`/hq:start` が pr skill の invariants を bypass しうるという残存印象がない）
- [ ] [manual] bootstrap template の PR Body Structure セクションは自己完結 — 新しく bootstrap されたレポジトリがこのファイルのみを受け取っても invariants を理解できる（`pr/SKILL.md` を読まなくても）

---
Closes #11
Refs #10