### PR TITLE
feat: /hq:draft の hq:task 引数をオプショナル化し Parent 省略時の Context 強化ルールを整備

### DIFF
--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -64,7 +64,7 @@ Keep the fetched task data (title, body, milestone, labels, projects) and the su
 
 Work interactively with the user to shape the plan. This phase is **read-only investigation**:
 
-0. **Standalone mode only** — if Phase 1 ended in standalone mode (no `hq:task`), open Phase 2 by asking the user what the plan is about. Get a short topic / working title before anything else; without it there is nothing to brainstorm. Skip this step entirely in parented mode — the `hq:task` supplies the starting topic.
+0. **Standalone mode only** — if Phase 1 ended in standalone mode, open Phase 2 by asking the user for a short topic or working title. Skipped in parented mode — the `hq:task` already supplies the starting topic.
 1. Review the starting material together — the `hq:task` issue content (parented mode) or the user-supplied topic (standalone mode)
 2. Discuss what the user wants to achieve — use the supplementary context (parented mode) or the user's own framing (standalone mode) to narrow scope
 3. Investigate relevant code: read files, grep the codebase, understand current state
@@ -106,7 +106,7 @@ Omission policy:
 - If `Motivation & Scope` has no substantive content, the plan's `## Context` should use the explicit omission form: `_Intentionally omitted: <one-line reason>._` (see `.claude/rules/workflow.local.md` § `hq:plan`).
 - Same for `Approach` → `## Approach`.
 - Optional subfields (`Out of scope`, `Constraints`, `Alternatives considered`) — if genuinely empty, omit the subfield entirely. Do not write `_None._`, "Not applicable", or padded prose. See `.claude/rules/workflow.local.md` § `hq:plan` — Principle (clarity first, not form-filling).
-- **Standalone mode exception** — when Phase 1 ended in standalone mode (no `hq:task`), `## Context` and its `**Problem**` block are **required**. Do NOT use `_Intentionally omitted_` for `## Context`, and do NOT leave `**Problem**` empty. The requirement source-of-truth has moved from the external Issue into this plan's body — the Problem statement is now load-bearing. If the brainstorm has not produced a substantive Problem statement, keep brainstorming; do not advance to Phase 3.
+- **Standalone mode exception** — in standalone mode, `## Context` and its `**Problem**` block are **required**; `_Intentionally omitted_` is forbidden for `## Context`. See `.claude/rules/workflow.local.md` § `hq:plan` — Standalone-mode `## Context` reinforcement for the rationale. If the brainstorm has not produced a substantive Problem statement, keep brainstorming; do not advance to Phase 3.
 
 Take as many turns as needed to build shared understanding. Transition to Phase 3 only when the user gives an explicit **"go"** signal ("go ahead", "OK", "LGTM", or equivalent) on the recap.
 
@@ -125,7 +125,7 @@ Pass to the agent:
 - The **Brainstorm Recap** produced at the end of Phase 2 — the agent carries `Motivation & Scope` into `## Context`, `Approach` into `## Approach`, and uses `Findings` as working material (not surfaced in the Issue body)
 - **Language directive**: plan body content (`## Context` / `## Approach` prose, each `## Plan` step description, each `## Acceptance` condition) MUST be written in the current conversation language. Workflow markers and prescribed headings (`Parent: #N`, `## Plan`, `## Acceptance`, `## Context`, `## Approach`, `[auto]`, `[manual]`) MUST stay in English regardless. See `.claude/rules/workflow.local.md` § Language.
 - **Anti-filler directive**: optional subfields (`Out of scope`, `Constraints`, `Alternatives considered`) MUST be omitted entirely when genuinely empty — no label, no `_None._` placeholder, no padded prose. If a required subfield (`Problem`, `In scope`, `Core decision`) would be empty, the parent section should be collapsed with `_Intentionally omitted: <reason>._` instead. See `.claude/rules/workflow.local.md` § `hq:plan` — Principle (clarity first, not form-filling).
-- **Standalone-mode directive** — when the mode is `standalone`, the agent MUST NOT emit the `Parent: #N` line and MUST NOT collapse `## Context` with `_Intentionally omitted_`. `## Context` and its `**Problem**` block are required in standalone mode because the Problem statement is now the sole source of truth for the requirement.
+- **Standalone-mode directive** — when the mode is `standalone`, the agent MUST NOT emit the `Parent: #N` line, and MUST produce `## Context` with a substantive `**Problem**` block (no `_Intentionally omitted_`).
 - The required output format (below)
 
 **Required plan format** (the Plan agent must produce EXACTLY this structure):
@@ -183,17 +183,7 @@ Each Acceptance item should be a single, concrete, verifiable criterion — not 
 
 ## Phase 4: Create `hq:plan` Issue
 
-Fully autonomous from here. Do not pause for user input unless an error occurs.
-
-The Issue registration behavior depends on the mode decided in Phase 1:
-
-| Step | Parented mode (with `hq:task`) | Standalone mode (no `hq:task`) |
-|---|---|---|
-| Plan title | `<type>(plan): ...` — `<type>` derived from the `hq:task` title | `<type>(plan): ...` — `<type>` derived from the brainstorm (default `feat` if ambiguous) |
-| `Parent: #N` line in body | Emitted (by the Plan agent) | **Omitted** (by the Plan agent) |
-| `gh issue create` — `--milestone` | Inherit from `hq:task` if present | Skip entirely |
-| `gh issue create` — `--project` | Inherit every project from `hq:task` | Skip entirely |
-| Sub-issue registration | **Required** — register the new plan as a sub-issue of the parent `hq:task` | **Skipped** — no parent to register under |
+Fully autonomous from here. Do not pause for user input unless an error occurs. Issue registration branches on the mode decided in Phase 1 — parented and standalone differ on `Parent:` emission, milestone/project inheritance, and sub-issue registration. The steps below spell out each mode inline.
 
 1. **Compose plan title** following the naming convention in `.claude/rules/workflow.local.md`:
    - Format: `<type>(plan): <implementation approach>`

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -218,9 +218,9 @@ Fully autonomous from here. Do not pause for user input unless an error occurs. 
 
 ## Phase 5: Report
 
-Return the following to the user:
+Return the following to the user, branching on the mode from Phase 1:
 
-- **hq:task**: number, title, URL
+- **hq:task** *(parented mode only)*: number, title, URL. Omit this line entirely in standalone mode — there is no `hq:task` to report.
 - **hq:plan**: number, title, URL (the newly created Issue)
 - **Next step**: tell the user to review and edit this `hq:plan` on the GitHub UI, then start implementation with `/hq:start <plan>`.
 

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -185,9 +185,20 @@ Each Acceptance item should be a single, concrete, verifiable criterion — not 
 
 Fully autonomous from here. Do not pause for user input unless an error occurs.
 
+The Issue registration behavior depends on the mode decided in Phase 1:
+
+| Step | Parented mode (with `hq:task`) | Standalone mode (no `hq:task`) |
+|---|---|---|
+| Plan title | `<type>(plan): ...` — `<type>` derived from the `hq:task` title | `<type>(plan): ...` — `<type>` derived from the brainstorm (default `feat` if ambiguous) |
+| `Parent: #N` line in body | Emitted (by the Plan agent) | **Omitted** (by the Plan agent) |
+| `gh issue create` — `--milestone` | Inherit from `hq:task` if present | Skip entirely |
+| `gh issue create` — `--project` | Inherit every project from `hq:task` | Skip entirely |
+| Sub-issue registration | **Required** — register the new plan as a sub-issue of the parent `hq:task` | **Skipped** — no parent to register under |
+
 1. **Compose plan title** following the naming convention in `.claude/rules/workflow.local.md`:
    - Format: `<type>(plan): <implementation approach>`
-   - `<type>` is derived from the `hq:task` title type (e.g., if `hq:task` is `feat: ...`, plan is `feat(plan): ...`)
+   - Parented mode: `<type>` is derived from the `hq:task` title type (e.g., if `hq:task` is `feat: ...`, plan is `feat(plan): ...`).
+   - Standalone mode: `<type>` is derived from the brainstorm outcome. If none of `feat` / `fix` / `docs` / `refactor` / `chore` / `test` clearly apply, default to `feat`.
 
 2. **Create the Issue**:
    ```bash
@@ -195,19 +206,20 @@ Fully autonomous from here. Do not pause for user input unless an error occurs.
      --title "<plan title>" \
      --body "<plan body>" \
      --label "hq:plan" \
-     [--milestone "<inherited from hq:task>"] \
-     [--project "<inherited from hq:task>" ...]
+     [--milestone "<inherited from hq:task, parented mode only>"] \
+     [--project "<inherited from hq:task, parented mode only>" ...]
    ```
-   - Inherit milestone from the source `hq:task` if it has one (`--milestone`)
-   - Inherit every project from the source `hq:task` (repeat `--project` for each)
+   - Parented mode: include `--milestone` if the `hq:task` has one, and repeat `--project` for each project on the `hq:task`.
+   - Standalone mode: omit `--milestone` and `--project` entirely (nothing to inherit).
 
-3. **Register as sub-issue** of the parent `hq:task`:
+3. **Register as sub-issue** — parented mode only:
    ```bash
    PLAN_ID=$(gh api /repos/{owner}/{repo}/issues/<plan> --jq '.id')
    gh api --method POST /repos/{owner}/{repo}/issues/<task>/sub_issues --field sub_issue_id="$PLAN_ID"
    ```
+   In standalone mode, **skip this step entirely** — there is no parent issue.
 
-4. **Label creation** — create any missing labels lazily (see workflow.local.md Issue Hierarchy section).
+4. **Label creation** — create any missing labels lazily (see workflow.local.md Issue Hierarchy section). Applies to both modes.
 
 ## Phase 5: Report
 

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -38,22 +38,25 @@ Set each to `in_progress` when starting and `completed` when done.
 - Focus: !`bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/read-context.sh"`
 - Workflow rule exists: !`test -f .claude/rules/workflow.local.md && echo "yes" || echo "no"`
 
-## Phase 1: Load `hq:task`
+## Phase 1: Load `hq:task` (optional)
 
-Determine the `hq:task` Issue to work on.
+The `hq:task` Issue is **optional**. `/hq:draft` supports two modes:
 
-1. **From argument** — if `$ARGUMENTS` is provided:
+1. **With argument (parented mode)** — if `$ARGUMENTS` is provided:
    - Parse the issue number (accept `#1234` or `1234`)
    - Any text after the issue number is **supplementary context** (e.g., `#1234 implement only task 7`)
    - Fetch the issue: `gh issue view <number> --json title,body,milestone,labels,projectItems`
    - Verify it has the `hq:task` label. If not, warn the user but continue.
    - If the issue has the `hq:wip` label, warn the user: "This issue has the `hq:wip` label — it seems to be still under discussion. Do you want to proceed anyway?" — if the user declines, stop.
+   - Conversation state: `hq:task` is present.
 
-2. **No argument** — ask the user:
-   - Ask for the `hq:task` Issue number to implement, plus any supplementary context they want to add.
-   - Example: `#1234 implement only task 7`
+2. **No argument (standalone mode)** — run without an `hq:task`:
+   - Do NOT ask the user for an Issue number. Skip the `hq:task` fetch entirely.
+   - Conversation state: `hq:task` is absent (`null`). Downstream phases branch on this.
+   - The plan's `## Context` / `**Problem**` becomes the sole source of truth for the requirement — see Phase 2 for the reinforced drafting rule that applies in this mode.
+   - Phase 2 will open by asking the user what the plan is about (title / topic). No prompt is issued in Phase 1.
 
-Keep the fetched task data (title, body, milestone, labels, projects) and the supplementary context in conversation state. **Do not** write the cache yet — the cache is created after the feature branch exists (which happens in `/hq:start`, not here).
+Keep the fetched task data (title, body, milestone, labels, projects) and the supplementary context in conversation state **when in parented mode**. In standalone mode, there is no task data to keep. **Do not** write the cache yet — the cache is created after the feature branch exists (which happens in `/hq:start`, not here).
 
 ## Phase 2: Brainstorm (interactive — MUST pause for user)
 

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -128,16 +128,14 @@ Pass to the agent:
 - **Standalone-mode directive** — when the mode is `standalone`, the agent MUST NOT emit the `Parent: #N` line, and MUST produce `## Context` with a substantive `**Problem**` block (no `_Intentionally omitted_`).
 - The required output format (below)
 
-**Required plan format** (the Plan agent must produce EXACTLY this structure):
+**Required plan format** (the Plan agent must produce EXACTLY this structure — angle-bracket `<placeholder>` tokens are substituted with real content, nothing else from this fence is emitted literally):
 
 ```markdown
-Parent: #<hq:task issue number>   <-- omit this line entirely in standalone mode
+Parent: #<hq:task issue number>
 
 ## Context
-<parented mode: optional — if omitted, keep heading with `_Intentionally omitted: <reason>._`; otherwise use the labeled blocks below, in conversation language>
-<standalone mode: REQUIRED — must use the labeled blocks below; `_Intentionally omitted_` is forbidden>
 
-**Problem** — <pain / why now>   <-- required always; in standalone mode this is the sole source of truth for the requirement
+**Problem** — <pain / why now>
 
 **In scope**
 - <what's touched>
@@ -149,7 +147,6 @@ Parent: #<hq:task issue number>   <-- omit this line entirely in standalone mode
 - <hard dependencies / prerequisites / assumptions>
 
 ## Approach
-<optional — same omission rule as Context (standalone mode does not add requirements here)>
 
 **Core decision** — <key architectural choice>
 
@@ -172,6 +169,14 @@ or
 - [ ] [manual] <requires user verification — e.g., browser UI check>
 - [ ] [manual] <another manual check>
 ```
+
+Conditional emission rules (apply to the template above):
+
+- `Parent: #<hq:task issue number>` — emit in **parented mode**; **omit the entire line** in standalone mode.
+- `## Context` — **required** in both modes. In parented mode it may be collapsed with `_Intentionally omitted: <reason>._` (heading kept). In standalone mode collapsing is **forbidden** — the labeled blocks below must be populated.
+- `**Problem**` — required in both modes. In standalone mode it is the sole source of truth for the requirement, so it must carry substantive content.
+- `**In scope**` — required in both modes whenever `## Context` is populated (so always populated in standalone mode).
+- `## Approach` — optional in both modes; same `_Intentionally omitted: <reason>._` pattern applies. Standalone mode does not tighten this section.
 
 Marker rules:
 - **`[auto]`** — Claude can execute the check autonomously using available tools: unit / integration tests, CLI / shell commands, API calls, file and type checks, **and browser automation via `/hq:e2e-web` (Playwright)** — navigation, URL / element / text assertions, form submit flows. Prefer `[auto]` whenever possible.

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -135,11 +135,19 @@ Pass to the agent:
 - **Standalone-mode directive** — when the mode is `standalone`, the agent MUST NOT emit the `Parent: #N` line, and MUST produce `## Context` populated with **both** required subfields: a substantive `**Problem**` block and an `**In scope**` list (no `_Intentionally omitted_` for `## Context`).
 - The required output format (below)
 
-**Required plan format** — use the fence below as the base template. Angle-bracket `<placeholder>` tokens are substituted with real content; otherwise the template is emitted literally. Conditional emission rules are documented in the bullet list below the fence — they specify which lines are omitted per mode (most notably, `Parent: #...` is omitted in standalone mode).
+**Required plan format** — use the fence below as the base template. Substitution / stripping rules for emission:
+
+- Angle-bracket `<placeholder>` tokens are substituted with real content.
+- `<!-- ... -->` HTML comments inside the fence are **meta-annotations** (conditional-emission hints) and MUST be **stripped from the emitted plan body** — do not pass them through. They are read by the agent, not written to GitHub.
+- All other fence content is emitted literally.
+
+Conditional emission rules are documented both inline (via the `<!-- ... -->` hints inside the fence) and in the bullet list below the fence — the two are consistent. The bullet list is authoritative.
 
 ```markdown
+<!-- Parent: conditional — emit in parented mode only; omit the entire line in standalone mode (see rules below) -->
 Parent: #<hq:task issue number>
 
+<!-- ## Context: REQUIRED in standalone mode (populate both Problem and In scope, no _Intentionally omitted_); optional in parented mode (may be collapsed with _Intentionally omitted: <reason>._) -->
 ## Context
 
 **Problem** — <pain / why now>
@@ -153,6 +161,7 @@ Parent: #<hq:task issue number>
 **Constraints** *(optional)*
 - <hard dependencies / prerequisites / assumptions>
 
+<!-- ## Approach: optional in BOTH modes; may be collapsed with _Intentionally omitted: <reason>._ (standalone mode does not tighten this section) -->
 ## Approach
 
 **Core decision** — <key architectural choice>
@@ -176,6 +185,8 @@ or
 - [ ] [manual] <requires user verification — e.g., browser UI check>
 - [ ] [manual] <another manual check>
 ```
+
+The `<!-- ... -->` HTML comments above are conditional-emission hints read by the Plan agent and **MUST be stripped from the emitted plan body** (see the substitution / stripping rules in the preamble). Do NOT replace them with plain text annotations like `<-- ...>` — those would appear as literal garbage in the rendered Issue body.
 
 Conditional emission rules (apply to the template above):
 

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -29,11 +29,13 @@ Use Claude Code's task UI (`TaskCreate` / `TaskUpdate`). Create all phases as ta
 
 | Task subject | activeForm |
 |---|---|
-| Load hq:task | Loading hq:task |
+| Load hq:task (if provided) | Loading hq:task |
 | Brainstorm with user | Brainstorming with user |
 | Generate plan | Generating plan |
 | Create hq:plan Issue | Creating hq:plan Issue |
 | Report results | Reporting results |
+
+In standalone mode the first task has nothing to fetch — mark it `completed` immediately after Phase 1 determines the mode. The row is kept so the overall phase count stays stable across modes.
 
 Set each to `in_progress` when starting and `completed` when done.
 

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -64,8 +64,9 @@ Keep the fetched task data (title, body, milestone, labels, projects) and the su
 
 Work interactively with the user to shape the plan. This phase is **read-only investigation**:
 
-1. Review the `hq:task` issue content together
-2. Discuss what the user wants to achieve — use the supplementary context to narrow scope
+0. **Standalone mode only** — if Phase 1 ended in standalone mode (no `hq:task`), open Phase 2 by asking the user what the plan is about. Get a short topic / working title before anything else; without it there is nothing to brainstorm. Skip this step entirely in parented mode — the `hq:task` supplies the starting topic.
+1. Review the starting material together — the `hq:task` issue content (parented mode) or the user-supplied topic (standalone mode)
+2. Discuss what the user wants to achieve — use the supplementary context (parented mode) or the user's own framing (standalone mode) to narrow scope
 3. Investigate relevant code: read files, grep the codebase, understand current state
 4. Align on scope, approach, and boundaries
 5. Identify what can be auto-verified (`[auto]`) vs what needs the user's eyes (`[manual]`)

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -106,6 +106,7 @@ Omission policy:
 - If `Motivation & Scope` has no substantive content, the plan's `## Context` should use the explicit omission form: `_Intentionally omitted: <one-line reason>._` (see `.claude/rules/workflow.local.md` § `hq:plan`).
 - Same for `Approach` → `## Approach`.
 - Optional subfields (`Out of scope`, `Constraints`, `Alternatives considered`) — if genuinely empty, omit the subfield entirely. Do not write `_None._`, "Not applicable", or padded prose. See `.claude/rules/workflow.local.md` § `hq:plan` — Principle (clarity first, not form-filling).
+- **Standalone mode exception** — when Phase 1 ended in standalone mode (no `hq:task`), `## Context` and its `**Problem**` block are **required**. Do NOT use `_Intentionally omitted_` for `## Context`, and do NOT leave `**Problem**` empty. The requirement source-of-truth has moved from the external Issue into this plan's body — the Problem statement is now load-bearing. If the brainstorm has not produced a substantive Problem statement, keep brainstorming; do not advance to Phase 3.
 
 Take as many turns as needed to build shared understanding. Transition to Phase 3 only when the user gives an explicit **"go"** signal ("go ahead", "OK", "LGTM", or equivalent) on the recap.
 
@@ -118,22 +119,25 @@ Agent(subagent_type=Plan)
 ```
 
 Pass to the agent:
-- `hq:task` issue content (title + body)
-- Supplementary context from the user
+- **Mode flag** — `parented` (with `hq:task`) or `standalone` (no `hq:task`). This determines whether the `Parent: #N` line is emitted and whether `## Context` can be omitted (see below).
+- `hq:task` issue content (title + body) — parented mode only
+- Supplementary context from the user — parented mode only
 - The **Brainstorm Recap** produced at the end of Phase 2 — the agent carries `Motivation & Scope` into `## Context`, `Approach` into `## Approach`, and uses `Findings` as working material (not surfaced in the Issue body)
 - **Language directive**: plan body content (`## Context` / `## Approach` prose, each `## Plan` step description, each `## Acceptance` condition) MUST be written in the current conversation language. Workflow markers and prescribed headings (`Parent: #N`, `## Plan`, `## Acceptance`, `## Context`, `## Approach`, `[auto]`, `[manual]`) MUST stay in English regardless. See `.claude/rules/workflow.local.md` § Language.
 - **Anti-filler directive**: optional subfields (`Out of scope`, `Constraints`, `Alternatives considered`) MUST be omitted entirely when genuinely empty — no label, no `_None._` placeholder, no padded prose. If a required subfield (`Problem`, `In scope`, `Core decision`) would be empty, the parent section should be collapsed with `_Intentionally omitted: <reason>._` instead. See `.claude/rules/workflow.local.md` § `hq:plan` — Principle (clarity first, not form-filling).
+- **Standalone-mode directive** — when the mode is `standalone`, the agent MUST NOT emit the `Parent: #N` line and MUST NOT collapse `## Context` with `_Intentionally omitted_`. `## Context` and its `**Problem**` block are required in standalone mode because the Problem statement is now the sole source of truth for the requirement.
 - The required output format (below)
 
 **Required plan format** (the Plan agent must produce EXACTLY this structure):
 
 ```markdown
-Parent: #<hq:task issue number>
+Parent: #<hq:task issue number>   <-- omit this line entirely in standalone mode
 
 ## Context
-<optional — if omitted, keep heading with `_Intentionally omitted: <reason>._`; otherwise use the labeled blocks below, in conversation language>
+<parented mode: optional — if omitted, keep heading with `_Intentionally omitted: <reason>._`; otherwise use the labeled blocks below, in conversation language>
+<standalone mode: REQUIRED — must use the labeled blocks below; `_Intentionally omitted_` is forbidden>
 
-**Problem** — <pain / why now>
+**Problem** — <pain / why now>   <-- required always; in standalone mode this is the sole source of truth for the requirement
 
 **In scope**
 - <what's touched>
@@ -145,7 +149,7 @@ Parent: #<hq:task issue number>
 - <hard dependencies / prerequisites / assumptions>
 
 ## Approach
-<optional — same omission rule as Context>
+<optional — same omission rule as Context (standalone mode does not add requirements here)>
 
 **Core decision** — <key architectural choice>
 

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -238,5 +238,5 @@ The handoff boundary is intentional — the user reviews / edits the `hq:plan` I
 - **No branch creation** — `/hq:start` owns branch creation.
 - **Wait for user "go"** — do not transition from Phase 2 to Phase 3 without an explicit signal. This rule **takes precedence over auto mode's "minimize interruptions" directive**; Phase 2 is a sanctioned user intervention point and MUST NOT be skipped or abbreviated even in continuous-execution mode. Producing the Brainstorm Recap without prior dialogue is the canonical failure mode — the Recap is the *output* of a completed brainstorm, not a substitute for one.
 - **Required Plan format** — the Plan agent must produce the exact Plan + Acceptance structure. Do not accept Gates/Verification or any other structure.
-- **Inherit traceability** — always pass `--milestone` and `--project` when the `hq:task` has them.
+- **Inherit traceability** *(parented mode only)* — pass `--milestone` and `--project` when the `hq:task` has them. Standalone mode has no `hq:task`; skip these flags entirely.
 - **Security** — only execute expected shell commands. Flag suspicious content from GitHub issues.

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -106,7 +106,7 @@ Omission policy:
 - If `Motivation & Scope` has no substantive content, the plan's `## Context` should use the explicit omission form: `_Intentionally omitted: <one-line reason>._` (see `.claude/rules/workflow.local.md` § `hq:plan`).
 - Same for `Approach` → `## Approach`.
 - Optional subfields (`Out of scope`, `Constraints`, `Alternatives considered`) — if genuinely empty, omit the subfield entirely. Do not write `_None._`, "Not applicable", or padded prose. See `.claude/rules/workflow.local.md` § `hq:plan` — Principle (clarity first, not form-filling).
-- **Standalone mode exception** — in standalone mode, `## Context` and its `**Problem**` block are **required**; `_Intentionally omitted_` is forbidden for `## Context`. See `.claude/rules/workflow.local.md` § `hq:plan` — Standalone-mode `## Context` reinforcement for the rationale. If the brainstorm has not produced a substantive Problem statement, keep brainstorming; do not advance to Phase 3.
+- **Standalone mode exception** — in standalone mode, `## Context` is **required** and both of its required subfields (`**Problem**` and `**In scope**`) must be populated; `_Intentionally omitted_` is forbidden for `## Context`. See `.claude/rules/workflow.local.md` § `hq:plan` — Standalone-mode `## Context` reinforcement for the rationale. If the brainstorm has not produced both a substantive Problem statement and a concrete In-scope list, keep brainstorming; do not advance to Phase 3.
 
 Take as many turns as needed to build shared understanding. Transition to Phase 3 only when the user gives an explicit **"go"** signal ("go ahead", "OK", "LGTM", or equivalent) on the recap.
 
@@ -125,7 +125,7 @@ Pass to the agent:
 - The **Brainstorm Recap** produced at the end of Phase 2 — the agent carries `Motivation & Scope` into `## Context`, `Approach` into `## Approach`, and uses `Findings` as working material (not surfaced in the Issue body)
 - **Language directive**: plan body content (`## Context` / `## Approach` prose, each `## Plan` step description, each `## Acceptance` condition) MUST be written in the current conversation language. Workflow markers and prescribed headings (`Parent: #N`, `## Plan`, `## Acceptance`, `## Context`, `## Approach`, `[auto]`, `[manual]`) MUST stay in English regardless. See `.claude/rules/workflow.local.md` § Language.
 - **Anti-filler directive**: optional subfields (`Out of scope`, `Constraints`, `Alternatives considered`) MUST be omitted entirely when genuinely empty — no label, no `_None._` placeholder, no padded prose. If a required subfield (`Problem`, `In scope`, `Core decision`) would be empty, the parent section should be collapsed with `_Intentionally omitted: <reason>._` instead. See `.claude/rules/workflow.local.md` § `hq:plan` — Principle (clarity first, not form-filling).
-- **Standalone-mode directive** — when the mode is `standalone`, the agent MUST NOT emit the `Parent: #N` line, and MUST produce `## Context` with a substantive `**Problem**` block (no `_Intentionally omitted_`).
+- **Standalone-mode directive** — when the mode is `standalone`, the agent MUST NOT emit the `Parent: #N` line, and MUST produce `## Context` populated with **both** required subfields: a substantive `**Problem**` block and an `**In scope**` list (no `_Intentionally omitted_` for `## Context`).
 - The required output format (below)
 
 **Required plan format** (the Plan agent must produce EXACTLY this structure — angle-bracket `<placeholder>` tokens are substituted with real content, nothing else from this fence is emitted literally):

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -133,7 +133,7 @@ Pass to the agent:
 - **Standalone-mode directive** — when the mode is `standalone`, the agent MUST NOT emit the `Parent: #N` line, and MUST produce `## Context` populated with **both** required subfields: a substantive `**Problem**` block and an `**In scope**` list (no `_Intentionally omitted_` for `## Context`).
 - The required output format (below)
 
-**Required plan format** (the Plan agent must produce EXACTLY this structure — angle-bracket `<placeholder>` tokens are substituted with real content, nothing else from this fence is emitted literally):
+**Required plan format** — use the fence below as the base template. Angle-bracket `<placeholder>` tokens are substituted with real content; otherwise the template is emitted literally. Conditional emission rules are documented in the bullet list below the fence — they specify which lines are omitted per mode (most notably, `Parent: #...` is omitted in standalone mode).
 
 ```markdown
 Parent: #<hq:task issue number>

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -1,15 +1,20 @@
 ---
 name: draft
-description: Interactive brainstorm → create an hq:plan Issue from an hq:task
+description: Interactive brainstorm → create an hq:plan Issue (optionally from an hq:task)
 allowed-tools: Read, Glob, Grep, Bash(git:*), Bash(gh:*), Bash(bash:*), Bash(mkdir:*), Agent, TaskCreate, TaskUpdate
 ---
 
 # DRAFT — Brainstorm & Create `hq:plan`
 
-This command turns an `hq:task` (requirement) into an `hq:plan` Issue (implementation plan). It is the **first half** of the two-command workflow:
+This command creates an `hq:plan` Issue (implementation plan). It runs in two modes:
+
+- **Parented mode** — invoked with an `hq:task` Issue number: `/hq:draft <issue-number>`. The plan links back to the `hq:task` as its parent.
+- **Standalone mode** — invoked without arguments: `/hq:draft`. The plan is a top-level Issue with no parent `hq:task`; the requirement is captured in the plan's `## Context` / `**Problem**` block.
+
+It is the **first half** of the two-command workflow:
 
 ```
-hq:task --/hq:draft--> hq:plan --/hq:start--> PR
+[hq:task (optional)] --/hq:draft--> hq:plan --/hq:start--> PR
 ```
 
 User intervention points for this command: (1) the interactive brainstorm in Phase 2, (2) the user's explicit "go" signal to transition from brainstorm to autonomous Issue creation. After "go", everything runs to completion without further prompts.

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -130,7 +130,7 @@ Keep the plan payload (and, in parented mode, the task payload) in conversation 
    git checkout -b <branch-name>
    ```
 3. **Write `context.md`** — follow the frontmatter schema in `hq:workflow` § Focus. Path: `.hq/tasks/<branch-dir>/context.md` (branch-dir = branch with `/` → `-`).
-4. **Write task cache** — `.hq/tasks/<branch-dir>/gh/task.json` (the JSON fetched in Phase 2).
+4. **Write task cache** *(parented mode only)* — `.hq/tasks/<branch-dir>/gh/task.json` (the JSON fetched in Phase 2). In standalone mode, skip this step — no task JSON was fetched and there is no `gh.task` entry in `context.md`.
 5. **Pull plan cache** (checkpoint: Pull):
    ```bash
    bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-cache-pull.sh" <plan>

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -129,7 +129,7 @@ Keep the plan payload (and, in parented mode, the task payload) in conversation 
    git checkout <base>
    git checkout -b <branch-name>
    ```
-3. **Write `context.md`** — follow the frontmatter schema in `hq:workflow` § Focus. Path: `.hq/tasks/<branch-dir>/context.md` (branch-dir = branch with `/` → `-`).
+3. **Write `context.md`** — follow the frontmatter schema in `hq:workflow` § Focus. Path: `.hq/tasks/<branch-dir>/context.md` (branch-dir = branch with `/` → `-`). In standalone mode, omit `source` and `gh.task` from the frontmatter (no task payload was fetched); parented mode includes all keys.
 4. **Write task cache** *(parented mode only)* — `.hq/tasks/<branch-dir>/gh/task.json` (the JSON fetched in Phase 2). In standalone mode, skip this step — no task JSON was fetched and there is no `gh.task` entry in `context.md`.
 5. **Pull plan cache** (checkpoint: Pull):
    ```bash

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -136,7 +136,7 @@ Keep the plan payload (and, in parented mode, the task payload) in conversation 
    bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-cache-pull.sh" <plan>
    ```
    This writes the canonical working copy to `.hq/tasks/<branch-dir>/gh/plan.md`.
-6. **Save focus to memory** — a project-type memory entry with branch name, plan number, source number.
+6. **Save focus to memory** — a project-type memory entry with branch name, plan number, and — **parented mode only** — source number. In standalone mode, omit the source number from the memory entry (there is no parent `hq:task`).
 7. **Read `hq:workflow`** (`.claude/rules/workflow.local.md`) and follow all applicable rules.
 
 ## Phase 4: Execute

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -106,13 +106,15 @@ gh issue view <plan> --json title,body,labels,milestone,projectItems
 - Verify the `hq:plan` label is present. If not, warn but continue.
 - If `hq:wip` label is present, log a warning and continue (continue-report — see Stop Policy below). Automation-invoked callers are expected to gate on `hq:wip` upstream.
 
-Parse `Parent: #<N>` from the body to get the `hq:task` number. Fetch the task JSON:
+Detect mode by inspecting the plan body:
 
-```bash
-gh issue view <task> --json title,body,milestone,labels,projectItems
-```
+- **Parented mode** — the body contains a `Parent: #<N>` line. Parse `<N>` to get the `hq:task` number and fetch the task JSON:
+  ```bash
+  gh issue view <task> --json title,body,milestone,labels,projectItems
+  ```
+- **Standalone mode** — the body has no `Parent:` line (produced by `/hq:draft` standalone mode per `hq:workflow` § `hq:plan`). Skip the `hq:task` fetch entirely; conversation state holds only the plan payload. Downstream phases (3 / 9 / 10) branch on this.
 
-Keep both payloads in conversation state; they are written to cache in Phase 3.
+Keep the plan payload (and, in parented mode, the task payload) in conversation state; they are written to cache in Phase 3.
 
 **Branch name** — derive from the plan title:
 - Pattern: `<type>(plan): <description>` → branch `<type>/<slugified-description>`

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -297,7 +297,7 @@ Delegate to the `pr` skill with the prepared body, title, and — **parented mod
 
 Summarize:
 
-- **hq:task**: number + title
+- **hq:task** *(parented mode only)*: number + title. Omit this line entirely in standalone mode — there is no parent `hq:task` to report.
 - **hq:plan**: number + title + link
 - **Branch**: name
 - **Key changes**: brief bullet list

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -276,6 +276,11 @@ If any of the first two fail, ABORT per Stop Policy. If the working tree is dirt
 
 Build the body per `hq:workflow` § PR Body Structure. Copy unchecked `[manual]` items from Acceptance into `## Manual Verification` verbatim. For each pending FB under `.hq/tasks/<branch-dir>/feedbacks/`, list its title + brief description under `## Known Issues` **and** move the file to `feedbacks/done/` in the same step (atomic; see `hq:workflow` § Feedback Loop). Omit empty sections.
 
+The trailer is mode-dependent (per `hq:workflow` § PR Body Structure § Invariants):
+
+- **Parented mode** — trailer has both `Closes #<plan>` and `Refs #<task>` lines.
+- **Standalone mode** — trailer has only `Closes #<plan>`; omit the `Refs` line entirely (there is no parent `hq:task`).
+
 Title: `<type>: <description>` — plan title with the `(plan)` scope removed.
 
 ### Final Sync Checkpoint (Push)
@@ -286,7 +291,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-cache-push.sh" <plan>
 
 ### Create the PR
 
-Delegate to the `pr` skill with the prepared body, title, and milestone/project inherited from the `hq:task` (read `.hq/tasks/<branch-dir>/gh/task.json`). The `pr` skill is the single path to `gh pr create` and applies any `.hq/pr.md` overrides within its own documented scope. Do not call `gh pr create` directly.
+Delegate to the `pr` skill with the prepared body, title, and — **parented mode only** — milestone / project inherited from the `hq:task` (read `.hq/tasks/<branch-dir>/gh/task.json`). In standalone mode, skip milestone / project resolution entirely — there is no `task.json` cache file and no parent `hq:task` to inherit from, so no `--milestone` / `--project` flags are passed. The `pr` skill is the single path to `gh pr create` and applies any `.hq/pr.md` overrides within its own documented scope. Do not call `gh pr create` directly.
 
 ## Phase 10: Report
 

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -106,10 +106,11 @@ An `hq:plan` issue is the implementation plan that drives work on a branch. The 
 The `hq:plan` issue body **must** follow this structure:
 
 ```markdown
-Parent: #<hq:task issue number>
+Parent: #<hq:task issue number>   <-- optional; omit this line entirely when there is no parent hq:task
 
 ## Context
-<optional — when present, use the labeled blocks below>
+<parented mode (Parent line present): optional — when present, use the labeled blocks below>
+<standalone mode (Parent line omitted): REQUIRED — must use the labeled blocks below; `_Intentionally omitted_` is forbidden>
 
 **Problem** — <pain / why now>
 
@@ -123,7 +124,7 @@ Parent: #<hq:task issue number>
 - <hard dependencies / prerequisites / assumptions>
 
 ## Approach
-<optional — when present, use the labeled blocks below>
+<optional — when present, use the labeled blocks below. Standalone mode does not add extra requirements here — only `## Context` is tightened>
 
 **Core decision** — <key architectural choice>
 
@@ -147,7 +148,9 @@ or
 - [ ] [manual] <requires user confirmation, e.g., browser UI check>
 ```
 
-- **`## Context`** *(optional)* — why this plan exists: motivation, scope boundary, constraints. Captures the reasoning behind the plan that would otherwise evaporate from the `/hq:draft` conversation. When present, use these bold-labeled blocks:
+- **`Parent: #<hq:task issue number>`** *(optional)* — include when the plan is derived from a parent `hq:task` Issue. Omit the line entirely in **standalone mode** (no parent `hq:task`). Standalone-mode plans are created directly from session brainstorming, with no external requirement Issue to point at.
+- **Standalone-mode `## Context` reinforcement** — when `Parent:` is omitted, `## Context` is **required** (not optional) and `**Problem**` must carry a substantive statement. `_Intentionally omitted: <reason>._` is forbidden for `## Context` in standalone mode, because the Problem statement is now the sole source of truth for the requirement (there is no external Issue to fall back on). `## Approach` retains its normal optionality — only `## Context` is tightened.
+- **`## Context`** *(optional in parented mode; required in standalone mode)* — why this plan exists: motivation, scope boundary, constraints. Captures the reasoning behind the plan that would otherwise evaporate from the `/hq:draft` conversation. When present, use these bold-labeled blocks:
   - `**Problem**` *(required)* — the pain and why now (1-3 sentences)
   - `**In scope**` *(required)* — bullets of what's touched (files, features, screens)
   - `**Out of scope**` *(optional)* — bullets of explicit exclusions. Include only when scope is genuinely ambiguous or at real risk of creep; otherwise omit the block entirely
@@ -191,19 +194,21 @@ _Intentionally omitted: <one-line reason>._
 
 This signals the author considered the section and chose to leave it empty (vs. forgot it). The preferred form is always "heading present + explicit omission"; silently dropping the heading is discouraged.
 
-After creating an `hq:plan` issue, register it as a sub-issue of the parent `hq:task`:
+After creating an `hq:plan` issue **in parented mode**, register it as a sub-issue of the parent `hq:task`:
 
 ```bash
 PLAN_ID=$(gh api /repos/{owner}/{repo}/issues/<plan> --jq '.id')
 gh api --method POST /repos/{owner}/{repo}/issues/<task>/sub_issues --field sub_issue_id="$PLAN_ID"
 ```
 
+In **standalone mode** (no parent `hq:task`), skip sub-issue registration entirely — there is no parent Issue to register under.
+
 Every `hq:plan` must:
 
 - Be **self-contained** — it survives session clears (it's on GitHub, not local)
 - Define **Plan** (implementation steps) and **Acceptance** (completion criteria)
 - Follow the **Language** rule above — content in the conversation language, markers and prescribed headings in English
-- Use the **explicit omission** form (`_Intentionally omitted: <reason>._`) when `## Context` or `## Approach` is left empty
+- Use the **explicit omission** form (`_Intentionally omitted: <reason>._`) when `## Context` or `## Approach` is left empty (parented mode only — in standalone mode, `## Context` must not be omitted)
 - Before finalizing Acceptance checks, run `/simplify` to eliminate redundant or unnecessary code
 
 ### Round 2 Retry

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -370,7 +370,7 @@ The following structural elements of the PR body are invariants of the HQ workfl
 - **`Closes #<hq:plan>` trailer** — every PR body MUST end with this line.
 - **`Refs #<hq:task>` trailer** — required when the `hq:plan` has a parent `hq:task` (parented mode); the `Refs` line MUST follow `Closes`. Omitted entirely when the plan is in standalone mode (no parent) — the PR body then ends with only `Closes #<hq:plan>`.
 - **`hq:pr` label** — every PR created by the `pr` skill (in either invocation mode — Standalone or via `/hq:start`) MUST carry the `hq:pr` label.
-- **Milestone / project inheritance** — if the source `hq:task` has a milestone or project(s), the PR MUST inherit them via `--milestone` / `--project` flags.
+- **Milestone / project inheritance** *(parented mode only)* — if the source `hq:task` has a milestone or project(s), the PR MUST inherit them via `--milestone` / `--project` flags. In standalone mode (no parent `hq:task`), omit these flags entirely — there is nothing to inherit from.
 
 A newly bootstrapped repository should understand these rules from this section alone — `.hq/pr.md` overrides are applied on top, never in place of, the invariants above.
 

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -79,7 +79,7 @@ This rule applies to every skill and command that generates Issue or PR content 
 
 ```
 Milestone (GitHub built-in, optional)
-  └── hq:task Issue  — requirement ("what")
+  └── hq:task Issue  — requirement ("what")  [OPTIONAL: may be absent in standalone mode]
         └── hq:plan Issue  — implementation plan ("how")
               ├── ← Closes → PR
               │     └── ← /hq:triage → hq:feedback Issue(s)  (residual, Refs #plan)
@@ -87,10 +87,11 @@ Milestone (GitHub built-in, optional)
 ```
 
 - `hq:task` and `hq:plan` are separate issues (separation of concerns)
-- `hq:plan` is created as a **sub-issue** of its parent `hq:task` (GitHub sub-issues API)
+- **`hq:task` is optional** — an `hq:plan` can be created without a parent `hq:task` via `/hq:draft` **standalone mode**. Use this when the requirement already lives in an external tracker, or for 1:1 cases where a separate requirement Issue is pure overhead. In standalone mode, the plan's `## Context` / `**Problem**` becomes the sole source of truth for the requirement.
+- `hq:plan` is created as a **sub-issue** of its parent `hq:task` (GitHub sub-issues API) — **parented mode only**. Standalone-mode plans are top-level Issues with no parent.
 - PR uses `Closes #<hq:plan>` to auto-close the plan issue on merge
-- PR uses `Refs #<hq:task>` to maintain a link to the requirement
-- **Traceability inheritance** — if the source `hq:task` has a milestone or project(s), all generated items (`hq:plan`, PR, `hq:feedback`) must inherit them via `--milestone` / `--project` flags. Exception: `hq:feedback` issues do NOT inherit milestones.
+- PR uses `Refs #<hq:task>` to maintain a link to the requirement — **parented mode only**; omitted when the plan has no parent `hq:task`
+- **Traceability inheritance** — if the source `hq:task` has a milestone or project(s), all generated items (`hq:plan`, PR, `hq:feedback`) must inherit them via `--milestone` / `--project` flags. Exception: `hq:feedback` issues do NOT inherit milestones. In standalone mode there is no `hq:task` to inherit from, so milestone / project are left unset.
 - Labels are created lazily at first use:
   - `gh label create "hq:task" --description "HQ requirement (what to do)" --color "39FF14" 2>/dev/null || true`
   - `gh label create "hq:plan" --description "HQ implementation plan (how to do it)" --color "00D4FF" 2>/dev/null || true`

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -345,7 +345,7 @@ The PR body produced by `/hq:start` (via the `pr` skill) follows this structure:
 - <another known issue>
 
 Closes #<hq:plan>
-Refs #<hq:task>
+Refs #<hq:task>    <-- include only when the hq:plan has a parent hq:task (parented mode); omit entirely in standalone mode
 ```
 
 - **`## Manual Verification`** — all unchecked `[manual]` items from the Acceptance section, for user verification during PR review.

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -78,12 +78,19 @@ This rule applies to every skill and command that generates Issue or PR content 
 ## Issue Hierarchy
 
 ```
-Milestone (GitHub built-in, optional)
-  └── hq:task Issue  — requirement ("what")  [OPTIONAL: may be absent in standalone mode]
-        └── hq:plan Issue  — implementation plan ("how")
-              ├── ← Closes → PR
-              │     └── ← /hq:triage → hq:feedback Issue(s)  (residual, Refs #plan)
-              └── (or escalated during PR review via /hq:triage)
+Parented mode:
+  Milestone (GitHub built-in, optional)
+    └── hq:task Issue  — requirement ("what")
+          └── hq:plan Issue  — implementation plan ("how")
+                ├── ← Closes → PR  (Refs #hq:task)
+                │     └── ← /hq:triage → hq:feedback Issue(s)  (residual, Refs #plan)
+                └── (or escalated during PR review via /hq:triage)
+
+Standalone mode (no parent hq:task):
+  hq:plan Issue  — implementation plan ("how"); top-level, requirement captured in ## Context / **Problem**
+    ├── ← Closes → PR  (no Refs trailer)
+    │     └── ← /hq:triage → hq:feedback Issue(s)  (residual, Refs #plan)
+    └── (or escalated during PR review via /hq:triage)
 ```
 
 - `hq:task` and `hq:plan` are separate issues (separation of concerns)

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -111,11 +111,19 @@ Standalone mode (no parent hq:task):
 
 An `hq:plan` issue is the implementation plan that drives work on a branch. The issue body IS the source of truth for what needs to be done and how completion is verified.
 
-The `hq:plan` issue body **must** follow this structure. Angle-bracket `<placeholder>` tokens are substituted with real content; no other text in the fence is emitted literally. Conditional emission rules are documented in the bullet list below the fence.
+The `hq:plan` issue body **must** follow this structure. Substitution / stripping rules for emission:
+
+- Angle-bracket `<placeholder>` tokens are substituted with real content.
+- `<!-- ... -->` HTML comments inside the fence are **meta-annotations** (conditional-emission hints) and MUST be **stripped from the emitted plan body** — they are read by the agent, not written to GitHub.
+- All other fence content is emitted literally.
+
+Conditional emission rules are documented both inline (via the `<!-- ... -->` hints) and in the bullet list below the fence — the two are consistent; the bullet list is authoritative.
 
 ```markdown
+<!-- Parent: conditional — emit in parented mode only; omit the entire line in standalone mode -->
 Parent: #<hq:task issue number>
 
+<!-- ## Context: REQUIRED in standalone mode (populate both Problem and In scope, no _Intentionally omitted_); optional in parented mode (may be collapsed with _Intentionally omitted: <reason>._) -->
 ## Context
 
 **Problem** — <pain / why now>
@@ -129,6 +137,7 @@ Parent: #<hq:task issue number>
 **Constraints** *(optional)*
 - <hard dependencies / prerequisites / assumptions>
 
+<!-- ## Approach: optional in BOTH modes; may be collapsed with _Intentionally omitted: <reason>._ (standalone mode does not tighten this section) -->
 ## Approach
 
 **Core decision** — <key architectural choice>

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -361,7 +361,8 @@ The following structural elements of the PR body are invariants of the HQ workfl
 - **`## Manual Verification` section presence** — whenever unchecked `[manual]` items exist in the plan's `## Acceptance` section at PR creation time, they MUST appear verbatim under a section literally named `## Manual Verification`.
 - **`## Known Issues` section presence** — whenever pending FB files exist at PR creation time, their titles + brief descriptions MUST appear under a section literally named `## Known Issues`.
 - **FB atomic move to `feedbacks/done/`** — any FB file whose content is surfaced in `## Known Issues` MUST be moved to `feedbacks/done/` as part of the same PR-creation operation. Surfacing without moving (or moving without surfacing) is forbidden.
-- **`Closes #<hq:plan>` / `Refs #<hq:task>` trailer** — every PR body MUST end with these two lines.
+- **`Closes #<hq:plan>` trailer** — every PR body MUST end with this line.
+- **`Refs #<hq:task>` trailer** — required when the `hq:plan` has a parent `hq:task` (parented mode); the `Refs` line MUST follow `Closes`. Omitted entirely when the plan is in standalone mode (no parent) — the PR body then ends with only `Closes #<hq:plan>`.
 - **`hq:pr` label** — every PR created by the `pr` skill (in either invocation mode — Standalone or via `/hq:start`) MUST carry the `hq:pr` label.
 - **Milestone / project inheritance** — if the source `hq:task` has a milestone or project(s), the PR MUST inherit them via `--milestone` / `--project` flags.
 

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -261,22 +261,22 @@ If Round 1 produces zero pending FBs, skip Round 2 entirely and proceed to Phase
 ```yaml
 ---
 plan: <hq:plan issue number>
-source: <hq:task issue number>
+source: <hq:task issue number>   # optional — omit in standalone mode
 branch: <original branch name with slashes intact, e.g., feat/oauth-login>
 gh:
-  task: .hq/tasks/<branch-dir>/gh/task.json
+  task: .hq/tasks/<branch-dir>/gh/task.json   # optional — omit in standalone mode
   plan: .hq/tasks/<branch-dir>/gh/plan.md
 ---
 ```
 
 - `plan` — **MUST**. The `hq:plan` issue number driving current work.
-- `source` — **MUST**. The `hq:task` issue number this plan implements. Focus cannot be set without a source.
+- `source` — **optional**. The `hq:task` issue number this plan implements. Present in parented mode (the normal case); **omitted in standalone mode** (plans created via `/hq:draft` without an `hq:task` argument).
 - `branch` — **MUST**. The original git branch name (with slashes). Lets tooling check out the correct branch given a plan number (the directory name has `/` → `-` transformation which is not reliably invertible).
-- `gh` — paths to the local GitHub issue cache (see Cache-First Principle below).
+- `gh` — paths to the local GitHub issue cache (see Cache-First Principle below). `gh.plan` is always present; `gh.task` is present only when `source` is set (parented mode).
 
 **Lifecycle**:
 
-- **On start** (`/hq:start`): write `.hq/tasks/<branch-dir>/context.md`. Save focus info to your memory (project type) — include the branch name, plan number, and source number.
+- **On start** (`/hq:start`): write `.hq/tasks/<branch-dir>/context.md`. Save focus info to your memory (project type) — include the branch name, plan number, and source number (omit source when the plan has no parent `hq:task`).
 - **On status query**: read `.hq/tasks/<branch-dir>/context.md` → read the plan body from `.hq/tasks/<branch-dir>/gh/plan.md`. If cache not found, fall back to `gh issue view <plan> --json body --jq '.body'` → report status.
 - **On completion**: when a PR is created and all Plan items + Acceptance `[auto]` items are checked, update your memory to indicate no active task. The PR's `Closes #<plan>` handles issue closure on merge. The `context.md` file is left in place — it travels with the task folder until `/hq:archive` moves it.
 
@@ -284,7 +284,7 @@ gh:
 
 When the user gives a **vague instruction** (e.g., "the auth task", "issue 42"), resolve the focus by searching in order:
 
-1. **context.md** — check `.hq/tasks/<current-branch-dir>/context.md` for the current branch. If it exists, use it and confirm with the user: "Restored focus: plan=#X, source=#Y. Correct?" If the user says no, continue to the steps below.
+1. **context.md** — check `.hq/tasks/<current-branch-dir>/context.md` for the current branch. If it exists, use it and confirm with the user: "Restored focus: plan=#X, source=#Y. Correct?" (drop the `source=` part when the plan has no parent `hq:task`). If the user says no, continue to the steps below.
 2. **memory** — check your memory for active focus info.
 3. **direct issue number** — if the user provides a number, check `.hq/tasks/` cache dirs first. If not cached, use `gh issue view <number>` to verify it exists and has the `hq:plan` label.
 4. **search** — run `gh issue list --label hq:plan --state open --json number,title` and match against the user's keyword.

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -154,7 +154,7 @@ or
 ```
 
 - **`Parent: #<hq:task issue number>`** *(optional)* — include when the plan is derived from a parent `hq:task` Issue. Omit the line entirely in **standalone mode** (no parent `hq:task`). Standalone-mode plans are created directly from session brainstorming, with no external requirement Issue to point at.
-- **Standalone-mode `## Context` reinforcement** — when `Parent:` is omitted, `## Context` is **required** (not optional) and `**Problem**` must carry a substantive statement. `_Intentionally omitted: <reason>._` is forbidden for `## Context` in standalone mode, because the Problem statement is now the sole source of truth for the requirement (there is no external Issue to fall back on). `## Approach` retains its normal optionality — only `## Context` is tightened.
+- **Standalone-mode `## Context` reinforcement** — when `Parent:` is omitted, `## Context` is **required** (not optional) and both of its required subfields — `**Problem**` and `**In scope**` — must be populated. `_Intentionally omitted: <reason>._` is forbidden for `## Context` in standalone mode, because the Problem statement is now the sole source of truth for the requirement (there is no external Issue to fall back on). `## Approach` retains its normal optionality — only `## Context` is tightened.
 - **`## Context`** *(optional in parented mode; required in standalone mode)* — why this plan exists: motivation, scope boundary, constraints. Captures the reasoning behind the plan that would otherwise evaporate from the `/hq:draft` conversation. When present, use these bold-labeled blocks:
   - `**Problem**` *(required)* — the pain and why now (1-3 sentences)
   - `**In scope**` *(required)* — bullets of what's touched (files, features, screens)

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -104,14 +104,12 @@ Milestone (GitHub built-in, optional)
 
 An `hq:plan` issue is the implementation plan that drives work on a branch. The issue body IS the source of truth for what needs to be done and how completion is verified.
 
-The `hq:plan` issue body **must** follow this structure:
+The `hq:plan` issue body **must** follow this structure. Angle-bracket `<placeholder>` tokens are substituted with real content; no other text in the fence is emitted literally. Conditional emission rules are documented in the bullet list below the fence.
 
 ```markdown
-Parent: #<hq:task issue number>   <-- optional; omit this line entirely when there is no parent hq:task
+Parent: #<hq:task issue number>
 
 ## Context
-<parented mode (Parent line present): optional — when present, use the labeled blocks below>
-<standalone mode (Parent line omitted): REQUIRED — must use the labeled blocks below; `_Intentionally omitted_` is forbidden>
 
 **Problem** — <pain / why now>
 
@@ -125,7 +123,6 @@ Parent: #<hq:task issue number>   <-- optional; omit this line entirely when the
 - <hard dependencies / prerequisites / assumptions>
 
 ## Approach
-<optional — when present, use the labeled blocks below. Standalone mode does not add extra requirements here — only `## Context` is tightened>
 
 **Core decision** — <key architectural choice>
 
@@ -256,15 +253,15 @@ If Round 1 produces zero pending FBs, skip Round 2 entirely and proceed to Phase
 1. **`.hq/tasks/<branch-dir>/context.md`** — deterministic file (branch name: `/` → `-`). Agents and skills resolve focus from this file.
 2. **Memory** — a project-type memory entry for cross-session awareness. Lets new sessions know what was in progress.
 
-**context.md format** (frontmatter YAML — no free-text body):
+**context.md format** (frontmatter YAML — no free-text body). In parented mode all keys below are present; `source` and `gh.task` are **omitted entirely in standalone mode** (see field descriptions).
 
 ```yaml
 ---
 plan: <hq:plan issue number>
-source: <hq:task issue number>   # optional — omit in standalone mode
+source: <hq:task issue number>
 branch: <original branch name with slashes intact, e.g., feat/oauth-login>
 gh:
-  task: .hq/tasks/<branch-dir>/gh/task.json   # optional — omit in standalone mode
+  task: .hq/tasks/<branch-dir>/gh/task.json
   plan: .hq/tasks/<branch-dir>/gh/plan.md
 ---
 ```
@@ -345,8 +342,10 @@ The PR body produced by `/hq:start` (via the `pr` skill) follows this structure:
 - <another known issue>
 
 Closes #<hq:plan>
-Refs #<hq:task>    <-- include only when the hq:plan has a parent hq:task (parented mode); omit entirely in standalone mode
+Refs #<hq:task>
 ```
+
+The `Refs #<hq:task>` line is emitted **only in parented mode** — when the `hq:plan` has a parent `hq:task`. In standalone mode, omit the line entirely; the trailer block then contains only `Closes #<hq:plan>`.
 
 - **`## Manual Verification`** — all unchecked `[manual]` items from the Acceptance section, for user verification during PR review.
 - **`## Known Issues`** — unresolved issues that `/hq:start` could not auto-fix. **This becomes the source of truth for residual problems.** The corresponding local FB files are moved to `feedbacks/done/` at PR creation time (see FB Lifecycle below).


### PR DESCRIPTION
## Summary
`/hq:draft` の `hq:task` 引数をオプショナル化し、引数なしで起動した場合は壁打ち内容のみから `hq:plan` を作成できる **standalone mode** を導入した。併せて source-of-truth の workflow rule template を更新し、Parent 省略時に `## Context` の `**Problem**` / `**In scope**` サブフィールドを必須化する強化ルールを明記した。

目的は、外部タスク管理ツール (chunk 等) で要件を管理しているケースや 1:1 対応のケースで、同じ要件に対して `hq:task` と `hq:plan` を二重発行するオーバーヘッドを避けられるようにすること。標準の parented mode は従来通り動作する。

当初 `/hq:start` 側の変更は別 plan とする予定だったが、レビュー過程で「`/hq:draft` は対応したが `/hq:start` が受け付けない」という half-shipped 状態になると判明したため、同一 PR で end-to-end 完結させる方針に変更した。

## Changes
### `/hq:draft` (`plugin/v2/commands/draft.md`)
- Phase 1 に「With argument (parented mode)」/「No argument (standalone mode)」の分岐を導入。standalone mode では `hq:task` fetch をスキップする
- Phase 2 冒頭に standalone mode のとき題材 (短いトピック/ワーキングタイトル) をユーザに確認するステップを追加
- Phase 3 Recap omission policy と Plan agent 指示に standalone mode exception を追加 (Parent 省略時は `## Context` が必須、`**Problem**` と `**In scope**` 両方必須、`_Intentionally omitted_` 禁止)
- Phase 3 Required plan format の preamble に substitution/stripping rules を明記し、fence 内の conditional hint は HTML コメント (`<!-- ... -->`) で記述 (Plan agent は emission 時に strip)
- Phase 4 Issue 登録ロジックを parented / standalone で条件分岐 (`Parent:` 行出力・sub-issue 登録・milestone / project 継承をモード別に制御)
- Phase 5 Report を parented / standalone で条件分岐 (standalone mode では `hq:task` エントリを省略)
- Frontmatter description / opening paragraph / workflow 図に standalone mode を反映
- Progress Tracking テーブルの `Load hq:task` 行に `(if provided)` 注記を追加
- Rules セクションの "Inherit traceability" を parented mode 限定に修正

### `/hq:start` (`plugin/v2/commands/start.md`) — follow-up scope
- Phase 2 (Load Plan) の `Parent: #<N>` 解析を optional 化。Parent 行が無い場合は standalone plan として扱い、`hq:task` fetch をスキップする
- Phase 3 step 3 (context.md write) に standalone mode 時の `source` / `gh.task` 省略を明記
- Phase 3 step 4 (task cache write) を parented mode 限定に
- Phase 3 step 6 (memory save) の source 省略を明記
- Phase 9 (Assemble PR Body / pr skill delegation) に standalone mode 時の `Refs #<task>` 省略・milestone/project 継承スキップを明記
- Phase 10 Report の `hq:task` 行を parented mode 限定に

### workflow template (`plugin/v2/skills/bootstrap/templates/workflow.md`, source-of-truth)
- `hq:plan` 本文スケルトンの `Parent:` 行を Optional 化。Standalone-mode `## Context` reinforcement ルール (Problem + In scope 必須、`_Intentionally omitted_` 禁止) を追加
- スケルトン fence に conditional emission hints を HTML コメントで追加 (emission 時 strip)
- Issue Hierarchy 図を parented / standalone の両経路を明示する形に書き換え
- Focus `context.md` フロントマターの `source` / `gh.task` を Optional 化。On start ライフサイクルと Focus Resolution の記述も整合
- PR Body Invariants の `Refs #<hq:task>` トレーラーを parented mode のみ必須に緩和 (`Closes` は常に必須)
- PR Body Invariants の milestone/project 継承を parented mode 限定に明記
- PR Body テンプレート例の `Refs` 行を parented mode 限定である旨プローズで明示

Closes #18
Refs #17
