### PR TITLE
fix: Phase 7 を diff 種別判定型に再設計し integrity-checker agent を新設

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,6 +5,7 @@
   "agents": [
     "./plugin/v2/agents/code-reviewer.md",
     "./plugin/v2/agents/security-scanner.md",
+    "./plugin/v2/agents/integrity-checker.md",
     "./plugin/v2/agents/review-comment-analyzer.md"
   ],
   "skills": "./plugin/v2/skills"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Skills, agents, and commands architecture. Skills define pure analysis criteria,
 
 Agents read skill files at runtime for analysis criteria, then handle workflow integration (focus resolution, file output, traceability) independently. They can run **in parallel** and in the **background**.
 
-`/hq:start` Phase 7 (Quality Review) is **diff-kind aware**: `code-reviewer` and `integrity-checker` always run; `security-scanner` and `/simplify` skip on doc-only diffs (the cost of running runtime / security reviewers on markdown is not paid for by their signal). See [plugin/v2/docs/workflow.md](plugin/v2/docs/workflow.md#commands) for the agent launch matrix.
+`/hq:start` Phase 7 (Quality Review) is **diff-kind aware**: `code-reviewer` and `integrity-checker` always run; `security-scanner` and `/simplify` skip on doc-only diffs (the cost of running runtime / security reviewers on markdown is not paid for by their signal). See [plugin/v2/docs/workflow.md](plugin/v2/docs/workflow.md#hqstart) for the agent launch matrix.
 
 **Commands** (user-invoked workflow shortcuts — invoked via `/hq:command-name`):
 
@@ -121,7 +121,7 @@ Parent: #<hq:task issue number>
 - Code review produces FB files instead of direct code modifications
 - Per-project overrides via `.hq/<skill>.md` files
 - Separate `security-scan` skill (was part of `reviewer` in v1)
-- `code-reviewer` and `security-scanner` agents enable parallel verification
+- `code-reviewer`, `security-scanner`, and `integrity-checker` agents enable parallel, diff-kind-aware verification
 
 #### Design Philosophy
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Skills, agents, and commands architecture. Skills define pure analysis criteria,
 | `pr`               | Create a pull request linked to `hq:plan` and `hq:task` issues                |
 | `code-review`      | Code review criteria — readability, correctness, performance, security         |
 | `security-scan`    | Security scan criteria — credentials, external comms, dynamic code, etc.       |
+| `integrity-check`  | End-to-end integrity criteria — downstream references, scope boundary, feature completeness |
 | `xcodebuild-config`| Interactive xcodebuild configuration (project, scheme, device, OS)             |
 | `e2e-web`          | End-to-end web verification via Playwright CLI                                 |
 | `worktree-setup`   | Create a new git worktree with local file setup (.env, .claude, .hq configs)   |
@@ -36,10 +37,13 @@ Skills, agents, and commands architecture. Skills define pure analysis criteria,
 | Agent                      | Description                                                                    |
 | -------------------------- | ------------------------------------------------------------------------------ |
 | `code-reviewer`            | Autonomous code review — reads `code-review` skill criteria, outputs report + FB files to `.hq/tasks/` |
-| `security-scanner`         | Autonomous security scan — reads `security-scan` skill criteria, outputs report to `.hq/tasks/` |
+| `security-scanner`         | Autonomous security scan — reads `security-scan` skill criteria, outputs report to `.hq/tasks/` (Haiku model — pattern detection) |
+| `integrity-checker`        | Autonomous integrity check — reads `integrity-check` skill criteria, looks beyond the hunks for downstream / scope-boundary / end-to-end gaps, outputs report + FB files to `.hq/tasks/` |
 | `review-comment-analyzer`  | Read-only analysis of a single PR review comment — classifies as Fix/Feedback/Dismiss with evidence. Launched in parallel by `/hq:respond` |
 
-Agents read skill files at runtime for analysis criteria, then handle workflow integration (focus resolution, file output, traceability) independently. Both agents can run **in parallel** and in the **background**.
+Agents read skill files at runtime for analysis criteria, then handle workflow integration (focus resolution, file output, traceability) independently. They can run **in parallel** and in the **background**.
+
+`/hq:start` Phase 7 (Quality Review) is **diff-kind aware**: `code-reviewer` and `integrity-checker` always run; `security-scanner` and `/simplify` skip on doc-only diffs (the cost of running runtime / security reviewers on markdown is not paid for by their signal). See [plugin/v2/docs/workflow.md](plugin/v2/docs/workflow.md#commands) for the agent launch matrix.
 
 **Commands** (user-invoked workflow shortcuts — invoked via `/hq:command-name`):
 

--- a/plugin/v2/agents/code-reviewer.md
+++ b/plugin/v2/agents/code-reviewer.md
@@ -16,10 +16,10 @@ description: >
 
   <example>
   Context: User wants parallel quality checks before PR
-  user: "Run review and scan before the PR."
-  assistant: "Launching code-reviewer and security-scanner in parallel."
+  user: "Run the pre-PR quality review."
+  assistant: "Launching code-reviewer, security-scanner, and integrity-checker in parallel (or the doc-diff subset per the matrix)."
   <commentary>
-  Pre-PR quality checks. Launch both agents in parallel.
+  Pre-PR quality checks follow the /hq:start Phase 7 Agent launch matrix: code-reviewer and integrity-checker always run; security-scanner skips on doc-only diffs.
   </commentary>
   </example>
 model: sonnet

--- a/plugin/v2/agents/integrity-checker.md
+++ b/plugin/v2/agents/integrity-checker.md
@@ -18,11 +18,20 @@ description: >
   </example>
 
   <example>
-  Context: User wants full quality review before PR
+  Context: User wants full quality review on a code / mixed diff before PR
   user: "Run the full quality review before the PR."
   assistant: "Launching code-reviewer, security-scanner, and integrity-checker in parallel."
   <commentary>
-  Pre-PR quality checks. Launch the full trio in parallel.
+  Pre-PR quality check on code / mixed diff: launch per the /hq:start Phase 7 Agent launch matrix.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants quality review on a doc-only diff
+  user: "Run the pre-PR review — it's a doc-only change."
+  assistant: "Launching code-reviewer and integrity-checker in parallel (security-scanner skipped per the doc-diff matrix)."
+  <commentary>
+  Pre-PR quality check on doc-only diff: security-scanner skips; code-reviewer and integrity-checker always run.
   </commentary>
   </example>
 model: sonnet

--- a/plugin/v2/agents/integrity-checker.md
+++ b/plugin/v2/agents/integrity-checker.md
@@ -1,0 +1,112 @@
+---
+name: integrity-checker
+description: >
+  Use this agent to detect end-to-end integrity gaps caused by a diff — stale downstream
+  references, hidden `## Out of scope` violations, and half-shipped features.
+  Looks **beyond** the hunks: extracts changed symbols / file paths / command / rule names
+  from the diff and greps the whole repo for surviving inconsistencies.
+  Reports findings with severity classification and outputs FB files for actionable issues.
+  Suitable for background execution.
+
+  <example>
+  Context: User requests an integrity check after a refactor
+  user: "Run an integrity check on this branch."
+  assistant: "Launching the integrity-checker agent."
+  <commentary>
+  Direct request for integrity check. Launch autonomously.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants full quality review before PR
+  user: "Run the full quality review before the PR."
+  assistant: "Launching code-reviewer, security-scanner, and integrity-checker in parallel."
+  <commentary>
+  Pre-PR quality checks. Launch the full trio in parallel.
+  </commentary>
+  </example>
+model: sonnet
+color: purple
+tools: ["Read", "Grep", "Glob", "Bash(git:*)", "Write", "TaskCreate", "TaskUpdate"]
+---
+
+You are an integrity checker agent. Detect end-to-end integrity gaps caused by the diff on the current branch: stale downstream references, scope-boundary violations hidden by the plan's `## Out of scope`, and half-shipped features. **Do not modify code directly.**
+
+## Load Criteria
+
+Read the skill file for review criteria and reporting format:
+`${CLAUDE_PLUGIN_ROOT}/skills/integrity-check/SKILL.md`
+
+From the skill file, extract and follow:
+- **Extraction Targets** — what to pull from the diff (symbols, file paths, commands, rule names, config keys, public API shape)
+- **Review Criteria** — the three classes of integrity violations to evaluate (downstream reference, scope boundary, end-to-end feature completeness)
+- **Fix Policy** — issues are reported, not fixed directly; scope carve-outs are not a defense
+- **Reporting Format** — grouping, severity classification, report structure
+- **Diff Scope** — what to include/exclude
+- **Project Overrides** — check `.hq/integrity-check.md`
+
+## Workflow Context
+
+1. **Project root**: `git rev-parse --show-toplevel`
+2. **Current branch**: `git rev-parse --abbrev-ref HEAD`
+3. **Base branch**: `.hq/settings.json` `base_branch` → `git symbolic-ref refs/remotes/origin/HEAD` → default `main`
+4. **Focus**: from the current branch name (step 2), compute the context path: `.hq/tasks/<branch-dir>/context.md` (branch-dir = branch name with `/` → `-`). Read it with the Read tool. If not found, treat as "none". If found, extract `plan` and `source` (GitHub issue numbers). Read the plan body from the local cache: `.hq/tasks/<branch-dir>/gh/plan.md` — do NOT call `gh issue view`. If the cache file does not exist, proceed without plan context.
+5. **Requirements**: if `docs/requirements.md` exists, use as reference
+
+## Progress Reporting
+
+Use TaskCreate and TaskUpdate to report progress so the parent session can track your work:
+
+1. At the start, create a task: `"Integrity Check: <branch>"` (status: in_progress)
+2. Create sub-tasks for each major step: Validate, Gather diff, Extract tokens, Grep downstream, Evaluate, Save report
+3. Update each sub-task to `completed` as you finish it
+4. Update the parent task to `completed` when done
+
+## Execution Flow
+
+1. **Validate**: abort if on base branch or no commits ahead of base
+2. **Gather diff** (in parallel) — apply exclusions from skill's Diff Scope:
+   - `git log <base>..HEAD --oneline`
+   - `git diff <base>...HEAD --stat`
+   - `git diff <base>...HEAD`
+3. **Extract tokens** from the diff per Extraction Targets — record symbol / path / command / rule-name / config-key / signature changes with their direction (added / removed / renamed / signature-changed)
+4. **Grep downstream** — for each removed / renamed / signature-changed token, search the whole repo (respecting exclusions) for surviving references. Use Grep aggressively; cover code, markdown, and config
+5. **Evaluate** against the three Review Criteria classes, informed by the plan's `## In scope` / `## Out of scope` / `## Approach` blocks. Treat `## Out of scope` as the **primary suspect zone** — the skill exists because scope carve-outs are where half-shipped features hide
+6. **Save**: write report and FB files (see File Output below)
+
+## Agent-Specific Rules
+
+- **Never pause for user confirmation** — if uncommitted changes exist, note them in the output but proceed with the committed diff.
+- Run fully autonomously from start to finish.
+- Do not modify source code — issues are reported via FB files only.
+- **Cross the scope boundary deliberately.** When the plan marks an area `## Out of scope` and the diff depends on it, that is exactly the case to report, not the case to suppress.
+- Restrict Bash usage to `git` commands.
+- Only write files under `.hq/tasks/`.
+
+## File Output (REQUIRED)
+
+You MUST save all output files to disk before returning. This is not optional.
+
+### Report
+1. Branch path: replace `/` with `-` in branch name (e.g., `feat/auth` → `feat-auth`)
+2. Create directory if needed: `.hq/tasks/<branch>/reports/`
+3. Write the full integrity-check report to `.hq/tasks/<branch>/reports/integrity-check-<YYYY-MM-DD-HHMM>.md`
+
+### FB Files
+4. For each actionable issue (any severity), create an FB file under `.hq/tasks/<branch>/feedbacks/`
+5. Check existing files in `feedbacks/` and `feedbacks/done/` to determine next number
+6. Format: `FB001.md`, `FB002.md`, etc. (zero-padded to 3 digits)
+7. Set frontmatter fields:
+   - `skill: /integrity-check`
+   - `source` and `plan`: from focus (step 4)
+
+Use the Write tool for every file — do not just return text.
+
+## Return Message
+
+After saving all files, return a brief summary to the caller:
+- **Report file path** (the file you just saved)
+- Total issues by severity
+- Count of `## Out of scope` violations (subset)
+- FB files created (with paths)
+- Informational items (no FB needed)

--- a/plugin/v2/agents/security-scanner.md
+++ b/plugin/v2/agents/security-scanner.md
@@ -21,7 +21,7 @@ description: >
   Parallel quality checks. Launch both agents simultaneously.
   </commentary>
   </example>
-model: sonnet
+model: haiku
 color: red
 tools: ["Read", "Grep", "Glob", "Bash(git:*)", "Write", "TaskCreate", "TaskUpdate"]
 ---

--- a/plugin/v2/agents/security-scanner.md
+++ b/plugin/v2/agents/security-scanner.md
@@ -14,11 +14,11 @@ description: >
   </example>
 
   <example>
-  Context: User wants code review and security scan in parallel
-  user: "Run code review and security scan in parallel."
-  assistant: "Launching code-reviewer and security-scanner in parallel."
+  Context: User wants parallel quality checks before PR on a code or mixed diff
+  user: "Run the pre-PR quality review on this feature branch."
+  assistant: "Launching code-reviewer, security-scanner, and integrity-checker in parallel."
   <commentary>
-  Parallel quality checks. Launch both agents simultaneously.
+  Pre-PR quality checks on code / mixed diff: launch per the /hq:start Phase 7 Agent launch matrix. On doc-only diffs, security-scanner is skipped.
   </commentary>
   </example>
 model: haiku

--- a/plugin/v2/agents/security-scanner.md
+++ b/plugin/v2/agents/security-scanner.md
@@ -28,6 +28,8 @@ tools: ["Read", "Grep", "Glob", "Bash(git:*)", "Write", "TaskCreate", "TaskUpdat
 
 You are a security scanner agent. Scan code changes on the current branch for security-sensitive patterns. **Detection only — no judgment, no fixes.**
 
+**Model choice** — this agent runs on `haiku`. The Alert Policy is pattern enumeration; detection does not require synthesis. If the policy changes to require contextual judgment, re-evaluate the model choice.
+
 ## Load Criteria
 
 Read the skill file for scan criteria and reporting format:

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -214,19 +214,96 @@ bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-cache-push.sh" <plan>   # che
 
 The `Phase 4 → Phase 5` loopback does NOT push between iterations — pushing happens once Phase 5 finally exits.
 
+## Diff Classification
+
+Phases 6 and 7 branch on the nature of the diff. Compute the classification once at the start of Phase 6 and reuse it in Phase 7 — `/simplify` may produce an additional commit, but it will not change the file-type mix, so the classification is stable across Phase 6 → Phase 7.
+
+### Rule
+
+Single-pass, extension-based, case-insensitive. Run over `git diff --name-only <base>...HEAD`:
+
+- **All changed files have a doc extension** → `doc`
+- **No changed file has a doc extension** → `code`
+- **Mix** → `mixed`
+
+Doc extensions (grouped for maintenance):
+
+| Group | Extensions |
+|---|---|
+| Markdown / structured text | `.md`, `.mdx`, `.markdown`, `.txt`, `.rst`, `.adoc`, `.asciidoc` |
+| Microsoft Office | `.docx`, `.doc`, `.pptx`, `.ppt`, `.xlsx`, `.xls` |
+| OpenDocument | `.odt`, `.odp`, `.ods` |
+| Google Docs (Drive shortcuts) | `.gdoc`, `.gsheet`, `.gslides` |
+| Apple iWork | `.pages`, `.numbers`, `.key` |
+| Portable | `.pdf`, `.rtf` |
+
+Anything not in the table above (including `.yaml`, `.json`, `.toml`, `.sh`, and other config / scripting formats) is treated as **code**.
+
+### Computing the classification
+
+Inline bash, 1-liner form (single pipeline — do not outsource to a helper script):
+
+```bash
+DIFF_KIND=$(git diff --name-only "$BASE"...HEAD | awk '
+  BEGIN { d=0; c=0 }
+  {
+    name=tolower($0)
+    if (name ~ /\.(md|mdx|markdown|txt|rst|adoc|asciidoc|docx|doc|pptx|ppt|xlsx|xls|odt|odp|ods|gdoc|gsheet|gslides|pages|numbers|key|pdf|rtf)$/) d=1
+    else c=1
+  }
+  END {
+    if (d && c) print "mixed"
+    else if (d) print "doc"
+    else print "code"
+  }')
+```
+
+Record `DIFF_KIND` in conversation state at the start of Phase 6 and reuse it in Phase 7.
+
+### Agent launch matrix
+
+The classification drives which agents / skills run in Phase 6 (Simplify) and Phase 7 (Quality Review):
+
+| `DIFF_KIND` | Phase 6 `/simplify` | Phase 7 `code-reviewer` | Phase 7 `security-scanner` | Phase 7 `integrity-checker` |
+|---|---|---|---|---|
+| `code` | ✓ | ✓ | ✓ | ✓ |
+| `doc` | — (skip) | ✓ | — (skip) | ✓ |
+| `mixed` | ✓ | ✓ | ✓ | ✓ |
+
+Rationale: `/simplify` and `security-scanner` target runtime / security concepts that do not apply to doc-only changes — running them burns tokens without producing useful output. `code-reviewer` still applies (prose quality, consistency) and `integrity-checker` is mandatory regardless (the skill's whole purpose is to catch gaps that hide precisely when `security-scanner` is silent).
+
 ## Phase 6: Simplify
 
-Run the `/simplify` skill on the full Acceptance-verified changeset. When it returns:
-
-1. Run `format` and `build`.
-2. If `/simplify` produced any changes, create a **single commit** per `hq:workflow` § Commit Policy. If no changes, skip the commit.
-3. **Immediately proceed to Phase 7.** Do not pause to review the simplification diff with the user, and do not ask for approval before committing — `/simplify`'s output is part of the autonomous flow. Concerns that cannot be resolved autonomously become FBs (continue-report per Stop Policy).
+1. Compute `DIFF_KIND` per `## Diff Classification` above and record it in conversation state.
+2. If `DIFF_KIND == doc` → **skip `/simplify` entirely** per the agent launch matrix. Do not create a commit. Proceed to Phase 7. The doc skip is tracked only in conversation state — nothing is written to the cache.
+3. Otherwise (`code` or `mixed`), run the `/simplify` skill on the full Acceptance-verified changeset. When it returns:
+   1. Run `format` and `build`.
+   2. If `/simplify` produced any changes, create a **single commit** per `hq:workflow` § Commit Policy. If no changes, skip the commit.
+   3. **Immediately proceed to Phase 7.** Do not pause to review the simplification diff with the user, and do not ask for approval before committing — `/simplify`'s output is part of the autonomous flow. Concerns that cannot be resolved autonomously become FBs (continue-report per Stop Policy).
 
 Phase 7 Quality Review is the safety net for behavior-affecting simplifications: if `/simplify` introduces a functional regression, `code-reviewer` is expected to flag it as an FB. No cache edits in this phase.
 
 ## Phase 7: Quality Review
 
-Run the **Quality Review** defined in `hq:workflow` § Quality Review: launch `code-reviewer` and `security-scanner` agents in parallel. Wait for both to complete, then process each FB they emit per the rule below.
+Phase 7 is **diff-kind aware**: the set of agents it launches depends on `DIFF_KIND` (§ Diff Classification). Fixed parallel launch is no longer the rule — we only run the agents that can produce useful signal for the diff's nature.
+
+### Step 1: Classify the diff
+
+Reuse the `DIFF_KIND` computed at the start of Phase 6. If it is missing (e.g., resume after interruption), recompute it from `git diff --name-only <base>...HEAD` using the same rule.
+
+### Step 2: Launch agents per the matrix
+
+Launch the agents selected by the agent launch matrix (§ Diff Classification) **in parallel** via the Agent tool. Wait for all launched agents to complete before proceeding.
+
+- `DIFF_KIND == code` → launch `code-reviewer`, `security-scanner`, `integrity-checker`
+- `DIFF_KIND == mixed` → launch `code-reviewer`, `security-scanner`, `integrity-checker` (same as `code`)
+- `DIFF_KIND == doc` → launch `code-reviewer`, `integrity-checker` **only** (skip `security-scanner`)
+
+`integrity-checker` is **always launched**. Its whole purpose is to catch downstream / scope-boundary / end-to-end gaps that the other two agents structurally cannot see — those gaps are most common when `security-scanner` is silent (doc diffs, rename-heavy refactors).
+
+Follow the **Quality Review** flow defined in `hq:workflow` § Quality Review for common rules (progress reporting, file output, FB conventions).
+
+### Step 3: Process FBs
 
 **Per-FB handling** — the FB retry cap (§ Settings) is applied **per FB independently**. FB X's failed retries do not consume FB Y's budget. For each FB:
 

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -216,11 +216,11 @@ The `Phase 4 → Phase 5` loopback does NOT push between iterations — pushing 
 
 ## Diff Classification
 
-Phases 6 and 7 branch on the nature of the diff. Compute the classification once at the start of Phase 6 and reuse it in Phase 7 — `/simplify` may produce an additional commit, but it will not change the file-type mix, so the classification is stable across Phase 6 → Phase 7.
+Phases 6 and 7 branch on the nature of the diff. Compute the classification at the start of Phase 6; Phase 7 recomputes if it is not already available (the `git diff --name-only` check is cheap, so recompute is not an optimization concern).
 
 ### Rule
 
-Single-pass, extension-based, case-insensitive. Run over `git diff --name-only <base>...HEAD`:
+Single-pass, extension-based, case-insensitive. Run over `git diff --name-only <base>...HEAD`. `DIFF_KIND` values: `code` | `doc` | `mixed`.
 
 - **All changed files have a doc extension** → `doc`
 - **No changed file has a doc extension** → `code`
@@ -258,7 +258,7 @@ DIFF_KIND=$(git diff --name-only "$BASE"...HEAD | awk '
   }')
 ```
 
-Record `DIFF_KIND` in conversation state at the start of Phase 6 and reuse it in Phase 7.
+Hold `DIFF_KIND` in conversation state across Phase 6 → Phase 7. If Phase 7 is resumed in a new session and the value is lost, recompute.
 
 ### Agent launch matrix
 
@@ -270,12 +270,12 @@ The classification drives which agents / skills run in Phase 6 (Simplify) and Ph
 | `doc` | — (skip) | ✓ | — (skip) | ✓ |
 | `mixed` | ✓ | ✓ | ✓ | ✓ |
 
-Rationale: `/simplify` and `security-scanner` target runtime / security concepts that do not apply to doc-only changes — running them burns tokens without producing useful output. `code-reviewer` still applies (prose quality, consistency) and `integrity-checker` is mandatory regardless (the skill's whole purpose is to catch gaps that hide precisely when `security-scanner` is silent).
+`integrity-checker` has no skip case by design — its whole purpose is to catch gaps that hide precisely when `security-scanner` is silent (doc diffs, rename-heavy refactors). `/simplify` and `security-scanner` target runtime / security concepts that do not apply to doc-only changes, so running them on `doc` burns tokens without useful output.
 
 ## Phase 6: Simplify
 
-1. Compute `DIFF_KIND` per `## Diff Classification` above and record it in conversation state.
-2. If `DIFF_KIND == doc` → **skip `/simplify` entirely** per the agent launch matrix. Do not create a commit. Proceed to Phase 7. The doc skip is tracked only in conversation state — nothing is written to the cache.
+1. Compute `DIFF_KIND` per `## Diff Classification` above.
+2. If `DIFF_KIND == doc` → **skip `/simplify` entirely** per the agent launch matrix. No commit, no cache write — proceed to Phase 7.
 3. Otherwise (`code` or `mixed`), run the `/simplify` skill on the full Acceptance-verified changeset. When it returns:
    1. Run `format` and `build`.
    2. If `/simplify` produced any changes, create a **single commit** per `hq:workflow` § Commit Policy. If no changes, skip the commit.
@@ -285,21 +285,15 @@ Phase 7 Quality Review is the safety net for behavior-affecting simplifications:
 
 ## Phase 7: Quality Review
 
-Phase 7 is **diff-kind aware**: the set of agents it launches depends on `DIFF_KIND` (§ Diff Classification). Fixed parallel launch is no longer the rule — we only run the agents that can produce useful signal for the diff's nature.
+Phase 7 launches the agent subset selected by `DIFF_KIND` (§ Diff Classification § Agent launch matrix).
 
 ### Step 1: Classify the diff
 
-Reuse the `DIFF_KIND` computed at the start of Phase 6. If it is missing (e.g., resume after interruption), recompute it from `git diff --name-only <base>...HEAD` using the same rule.
+Use `DIFF_KIND` from Phase 6. If it is not in state (resumed session, interrupted run), recompute from `git diff --name-only <base>...HEAD` using the same rule.
 
 ### Step 2: Launch agents per the matrix
 
-Launch the agents selected by the agent launch matrix (§ Diff Classification) **in parallel** via the Agent tool. Wait for all launched agents to complete before proceeding.
-
-- `DIFF_KIND == code` → launch `code-reviewer`, `security-scanner`, `integrity-checker`
-- `DIFF_KIND == mixed` → launch `code-reviewer`, `security-scanner`, `integrity-checker` (same as `code`)
-- `DIFF_KIND == doc` → launch `code-reviewer`, `integrity-checker` **only** (skip `security-scanner`)
-
-`integrity-checker` is **always launched**. Its whole purpose is to catch downstream / scope-boundary / end-to-end gaps that the other two agents structurally cannot see — those gaps are most common when `security-scanner` is silent (doc diffs, rename-heavy refactors).
+Launch the agents selected for `DIFF_KIND` by the **Agent launch matrix** (§ Diff Classification) in a single Agent-tool call batch so they run in parallel. Wait for all launched agents to complete before proceeding.
 
 Follow the **Quality Review** flow defined in `hq:workflow` § Quality Review for common rules (progress reporting, file output, FB conventions).
 

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -244,7 +244,7 @@ Anything not in the table above (including `.yaml`, `.json`, `.toml`, `.sh`, and
 Inline bash, 1-liner form (single pipeline — do not outsource to a helper script):
 
 ```bash
-DIFF_KIND=$(git diff --name-only "$BASE"...HEAD | awk '
+DIFF_KIND=$(git diff --name-only <base>...HEAD | awk '
   BEGIN { d=0; c=0 }
   {
     name=tolower($0)
@@ -285,7 +285,7 @@ Phase 7 Quality Review is the safety net for behavior-affecting simplifications:
 
 ## Phase 7: Quality Review
 
-Phase 7 launches the agent subset selected by `DIFF_KIND` (§ Diff Classification § Agent launch matrix).
+Phase 7 launches the agent subset selected by `DIFF_KIND` per the **Agent launch matrix** in `## Diff Classification` above.
 
 ### Step 1: Classify the diff
 
@@ -293,9 +293,9 @@ Use `DIFF_KIND` from Phase 6. If it is not in state (resumed session, interrupte
 
 ### Step 2: Launch agents per the matrix
 
-Launch the agents selected for `DIFF_KIND` by the **Agent launch matrix** (§ Diff Classification) in a single Agent-tool call batch so they run in parallel. Wait for all launched agents to complete before proceeding.
+Launch the agents selected for `DIFF_KIND` by the **Agent launch matrix** in `## Diff Classification` above. Issue them in a single Agent-tool call batch so they run in parallel; wait for all launched agents to complete before proceeding.
 
-Follow the **Quality Review** flow defined in `hq:workflow` § Quality Review for common rules (progress reporting, file output, FB conventions).
+Phase 7 Steps 1–3 **supersede** the three-step outline in `hq:workflow` § Quality Review — do not re-execute `hq:workflow § Quality Review` Steps 1 and 2 here. Only the common rules from `hq:workflow` (progress reporting, file output, FB conventions per `hq:workflow § Feedback Loop`) apply.
 
 ### Step 3: Process FBs
 
@@ -372,7 +372,7 @@ Summarize:
 - **hq:plan**: number + title + link
 - **Branch**: name
 - **Key changes**: brief bullet list
-- **Verification**: code-reviewer / security-scanner summary
+- **Verification**: summaries from every Phase 7 reviewer that ran per `## Diff Classification` (code-reviewer and integrity-checker always; security-scanner on `code` / `mixed` diffs)
 - **PR**: URL
 - **Manual verification items**: count (to be done by user in PR review)
 - **Known Issues**: count (handle via `/hq:triage <PR>` after review)

--- a/plugin/v2/docs/workflow.md
+++ b/plugin/v2/docs/workflow.md
@@ -119,7 +119,7 @@ Phase 5: Acceptance (sweep only — no fixing)
 │
 Phase 6: Simplify
 │  Classify diff: code / doc / mixed
-│  └─ doc  → skip /simplify (runtime-level reviewers don't apply to doc)
+│  └─ doc  → skip /simplify (simplification targets code constructs; no code to simplify)
 │  └─ else → /simplify → format + build → single commit (if changed)
 │
 Phase 7: Quality Review (diff-kind aware)

--- a/plugin/v2/docs/workflow.md
+++ b/plugin/v2/docs/workflow.md
@@ -118,13 +118,22 @@ Phase 5: Acceptance (sweep only — no fixing)
 │  Retry cap = FB retry cap (§ Settings, default 2)
 │
 Phase 6: Simplify
-│  /simplify → format + build → single commit (if changed)
+│  Classify diff: code / doc / mixed
+│  └─ doc  → skip /simplify (runtime-level reviewers don't apply to doc)
+│  └─ else → /simplify → format + build → single commit (if changed)
 │
-Phase 7: Quality Review
-│  ┌────────────────────────────────────────────┐
-│  │  code-reviewer    ║    security-scanner    │
-│  └──────────┬────────╨────────┬───────────────┘
-│             ▼                 ▼
+Phase 7: Quality Review (diff-kind aware)
+│  Reuse DIFF_KIND from Phase 6
+│  code / mixed:
+│    ┌──────────────────────────────────────────────────────────┐
+│    │  code-reviewer  ║  security-scanner  ║  integrity-checker │
+│    └────────┬────────╨──────────┬─────────╨─────────┬──────────┘
+│             ▼                   ▼                   ▼
+│  doc:
+│    ┌────────────────────────────────────────┐
+│    │  code-reviewer  ║  integrity-checker   │
+│    └────────┬────────╨──────────┬───────────┘
+│             ▼                   ▼
 │  Fix clearly-actionable FBs (per-FB, capped by § Settings FB retry cap)
 │  (working tree must be clean at end)
 │
@@ -155,6 +164,8 @@ Phase 10: Report
 - **Cache-first** — Phases 4–8 touch `.hq/tasks/<branch-dir>/gh/plan.md` only; GitHub is hit at sync checkpoints (after Phase 4 Execute, after Phase 5 Acceptance, after Phase 8 Round 2 Drafting if drafted, and before PR creation).
 - **Commit as you go** — each Plan item, simplify, and fix lands as its own commit. Working tree is clean by Phase 9.
 - **Acceptance → Simplify → Quality Review** — Phase 5 confirms the implementation works first (sweep only, looping back to Phase 4 to fix), Phase 6 then refactors a known-working baseline, Phase 7 reviews code quality on the simplified diff. Simplifying before Acceptance would tangle refactor with functional fixes; reviewing quality before Acceptance would waste effort on code that may not work.
+- **Diff-kind aware Phase 6 / Phase 7** — Phase 6 classifies the diff into `code` / `doc` / `mixed`. `/simplify` and `security-scanner` skip on `doc`-only diffs (runtime / security reviewers produce no useful signal on docs). `code-reviewer` and `integrity-checker` always run. The classification is stable across Phase 6 → Phase 7 (`/simplify` does not shift file types).
+- **Integrity is its own agent** — `integrity-checker` joins `code-reviewer` + `security-scanner` as a third Phase 7 reviewer. It reads the diff, extracts every referenceable token (symbols, file paths, commands, rule names, config keys, signature changes), and greps the whole repo for stale downstream references and scope-boundary violations. Whereas the other two agents look at the hunks, `integrity-checker` looks at the files the hunks depend on.
 - **Phase 4 ↔ Phase 5 mini-loop** — Phase 5 is a pure sweep; fixes live in Phase 4 (loopback entry). Capped by § Settings FB retry cap per item. This batch-fix model surfaces shared root causes across multiple failing items.
 - **Round 2 retry, capped** — if Phase 7 leaves pending FBs, Phase 8 appends `## Round 2` (Follow-ups + Plan + Acceptance) to the plan and re-enters Phases 4–7 once. No Round 3; residuals escalate to the PR's `## Known Issues`.
 - **PR body is the source of truth for residual problems** — unresolved FBs flow into `## Known Issues` and the local FB files move to `feedbacks/done/` atomically.

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -447,7 +447,7 @@ Wait for all launched agents to complete before proceeding.
 
 ### Step 3: Fix FB Issues
 
-Read pending FB files from every launched agent. Fix issues, run `format` and `build`, then re-run the originating agent to verify. Follow the FB Handling Rules in `## Feedback Loop`, using the caller's FB retry cap (for `/hq:start`, see its § Settings).
+Read pending FB files from `code-reviewer` and `integrity-checker` — these are the agents that output FB files. `security-scanner` findings appear only in its scan report and require human judgment (no FB files). Fix clearly-actionable FBs, run `format` and `build`, then re-run the originating agent to verify. Follow the FB Handling Rules in `## Feedback Loop`, using the caller's FB retry cap (for `/hq:start`, see its § Settings).
 
 ### Fallback: Interactive Mode
 

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -406,20 +406,48 @@ Acceptance must be satisfied (all `[auto]` items `[x]` — either truly passing,
 
 ## Quality Review
 
-Runs after Acceptance is satisfied. Verifies the diff meets the project's quality and security bar, independent of whether the plan was met.
+Runs after Acceptance is satisfied. Verifies the diff meets the project's quality, security, and end-to-end integrity bar, independent of whether the plan was met.
 
-### Step 1: Static Analysis (parallel)
+### Step 1: Classify the diff
 
-Launch `security-scanner` and `code-reviewer` agents **simultaneously** via the Agent tool. Both run autonomously and return summaries with report/FB file paths.
+Quality Review is **diff-kind aware** — the agent set depends on whether the diff is code, doc, or a mix. Single-pass, extension-based, case-insensitive classification of `git diff --name-only <base>...HEAD`:
 
-- **security-scanner** — security alert detection → report file
+- **All changed files have a doc extension** → `doc`
+- **No changed file has a doc extension** → `code`
+- **Mix** → `mixed`
+
+Doc extensions (case-insensitive):
+
+| Group | Extensions |
+|---|---|
+| Markdown / structured text | `.md`, `.mdx`, `.markdown`, `.txt`, `.rst`, `.adoc`, `.asciidoc` |
+| Microsoft Office | `.docx`, `.doc`, `.pptx`, `.ppt`, `.xlsx`, `.xls` |
+| OpenDocument | `.odt`, `.odp`, `.ods` |
+| Google Docs (Drive shortcuts) | `.gdoc`, `.gsheet`, `.gslides` |
+| Apple iWork | `.pages`, `.numbers`, `.key` |
+| Portable | `.pdf`, `.rtf` |
+
+Anything not in this table (including `.yaml`, `.json`, `.toml`, `.sh`, and other config / scripting formats) is treated as **code**.
+
+### Step 2: Static Analysis (parallel — set depends on kind)
+
+Launch the agent set selected by kind **simultaneously** via the Agent tool. All launched agents run autonomously and return summaries with report/FB file paths.
+
+| Kind | `code-reviewer` | `security-scanner` | `integrity-checker` |
+|---|---|---|---|
+| `code` | ✓ | ✓ | ✓ |
+| `doc` | ✓ | — (skip) | ✓ |
+| `mixed` | ✓ | ✓ | ✓ |
+
 - **code-reviewer** — quality review → report + FB files
+- **security-scanner** — security alert detection → report file (skipped on `doc` — doc-only diffs rarely carry injection / credential risk and wall-clock savings are real)
+- **integrity-checker** — downstream reference / scope boundary / end-to-end feature integrity → report + FB files. **Always launched** — its whole purpose is to catch gaps that the other two structurally cannot see, which is most common when `security-scanner` is silent (doc diffs, rename-heavy refactors)
 
-Wait for both agents to complete before proceeding.
+Wait for all launched agents to complete before proceeding.
 
-### Step 2: Fix FB Issues
+### Step 3: Fix FB Issues
 
-Read pending FB files from both agents. Fix issues, run `format` and `build`, then re-run the originating agent to verify. Follow the FB Handling Rules in `## Feedback Loop`, using the caller's FB retry cap (for `/hq:start`, see its § Settings).
+Read pending FB files from every launched agent. Fix issues, run `format` and `build`, then re-run the originating agent to verify. Follow the FB Handling Rules in `## Feedback Loop`, using the caller's FB retry cap (for `/hq:start`, see its § Settings).
 
 ### Fallback: Interactive Mode
 
@@ -427,6 +455,7 @@ If you need fine-grained control or mid-scan user interaction, use the skills di
 
 1. `/security-scan` — pauses on credential detection for user confirmation
 2. `/code-review` — warns about uncommitted changes
+3. `/integrity-check` — reports downstream reference / scope boundary / end-to-end integrity gaps
 
 If any step produces unresolved issues, do not skip ahead. Fix or get user confirmation before continuing.
 

--- a/plugin/v2/skills/integrity-check/SKILL.md
+++ b/plugin/v2/skills/integrity-check/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: integrity-check
+description: >
+  Detect end-to-end integrity gaps created by a diff — downstream references that were
+  not updated, half-shipped features, and hidden violations of the plan's `## Out of scope`.
+  Explicitly looks **beyond** the hunks: extracts changed symbols / file paths / command /
+  rule names from the diff and greps the whole repo for stale references.
+---
+
+## Project Overrides
+
+- Overrides: !`cat .hq/integrity-check.md 2>/dev/null || echo "none"`
+
+If `.hq/integrity-check.md` exists, its instructions take precedence over the defaults below (e.g., extra reference patterns, additional scope-boundary heuristics, excluded paths). Apply overrides on top of this skill's base flow.
+
+## Why This Skill Exists
+
+`code-review` looks at the hunks. `security-scan` looks at the hunks. Nothing looks at the files the hunks depend on. When a diff renames a helper, removes a command flag, or changes a rule name, downstream references that were **not touched** by the diff stay stale, and the feature ships half-wired. Plans try to guard this via `## Out of scope`, but scope carve-outs are frequently where the gaps hide: the plan says "X is out of scope," the change depends on X, X is not updated, and no reviewer objects because reviewers honor scope too strictly.
+
+This skill's job is to break that blind spot. It reads the diff, pulls every referenceable token out of the changed side, and greps the repo to verify downstream consumers are consistent. Violations are reported as FBs even when they fall outside the plan's `## In scope`.
+
+## Diff Scope
+
+Target:
+
+- `git log <base>..HEAD --oneline` — commit list
+- `git diff <base>...HEAD --stat` — changed-file summary
+- `git diff <base>...HEAD` — full diff (both sides; rename sources matter)
+
+Exclude from analysis:
+
+- `node_modules/`
+- Build artifacts (`.next/`, `dist/`, `coverage/`, `build/`)
+- Lock files (`bun.lock`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`)
+
+## Extraction Targets
+
+From the diff, extract every item that can be referenced from elsewhere. For each, record the token and the direction of change (added / removed / renamed / signature-changed).
+
+- **Symbols** — function / method / type / constant / enum-variant names introduced, removed, or renamed. Include language-level identifiers from added/removed declarations on both sides of the hunk.
+- **File paths** — paths that were created, deleted, moved, or renamed. Include both the old and the new path for renames.
+- **Command / subcommand names** — new or removed slash-commands (`/hq:<name>`), CLI subcommands, npm/bun scripts, mise tasks, make targets.
+- **Rule / section names** — structural heading names (`## Out of scope`, `## Known Issues`, `## Round 2`, …), FB field names, workflow-rule section names (`hq:workflow § <section>`), label names (`hq:plan`, `hq:pr`, …).
+- **Config keys** — JSON/YAML/TOML keys added or removed (e.g., `base_branch`, `allowed-tools`), environment variable names.
+- **Public API shape** — exported symbols whose signature (arguments, return type, frontmatter schema) changed. The token did not move, but its contract did — callers may silently break.
+
+## Review Criteria
+
+Given the extracted tokens, evaluate three classes of integrity violations:
+
+### 1. Downstream reference integrity
+
+For each **removed / renamed / signature-changed** token, grep the whole repo (respecting exclusions) for surviving references. Any hit outside the diff that still uses the old name / old signature is a stale reference.
+
+- Same-repo references in code and markdown
+- Workflow-rule citations (`hq:workflow § <section>`) that refer to renamed sections
+- Documentation that describes removed commands, flags, or files
+
+### 2. Scope boundary integrity
+
+A change declared "out of scope" is suspect when the same change also **depends on** the out-of-scope area. Flag cases where:
+
+- The diff's behavior requires an out-of-scope consumer to have been updated (e.g., new producer feature, consumer never reads it)
+- The diff introduces a producer/consumer asymmetry — upstream emits X, downstream was updated to require not-X elsewhere in history, and the two ends don't meet in the middle
+- Removing / renaming something in scope leaves the out-of-scope area referring to the old name
+
+Out-of-scope intent is respected only when the out-of-scope area is genuinely independent. If the change would be half-shipped without touching the out-of-scope area, the boundary is wrong — report it as an FB, not as a suggestion.
+
+### 3. End-to-end feature completeness
+
+Mentally trace the path from entrypoint to effect for each changed feature. Look for:
+
+- New entrypoint (command / route / agent) that is not wired in from any caller
+- New config key that nothing reads, or removed key that something still reads
+- New rule / section / heading whose consumers still look for the old one
+- Producer / consumer mismatch across layers (e.g., new frontmatter field, old validator; new label, old filter; new marker, old parser)
+
+If a feature cannot reach from its declared entrypoint to its declared effect using the current codebase, it is half-shipped. Report as an FB.
+
+## Severity Classification
+
+- **Critical** — the feature is broken end-to-end (entrypoint missing, consumer reads a non-existent key, removed name is still the only API surface)
+- **High** — stale reference survives and will misdirect users/tools (doc references a renamed command, rule file cites a deleted section)
+- **Medium** — inconsistency that is recoverable but will confuse (two names for the same thing coexist; one side updated, other side stale)
+- **Low** — cosmetic drift (wording mismatch, stale example with no behavioral consequence)
+
+## Fix Policy
+
+- **Do not modify code directly** — all issues are reported via FB files; the root agent decides what to fix
+- **Scope carve-outs are not a defense** — if the plan's `## Out of scope` is the reason a gap exists, report the gap and call out the scope violation explicitly
+- **Prefer under-reporting false positives over suppressing real gaps** — if integrity cannot be verified (grep is inconclusive), escalate to an FB with the evidence gathered
+
+## Reporting Format
+
+Report findings grouped by the three Review Criteria classes (Downstream reference integrity / Scope boundary integrity / End-to-end feature completeness). Within each group, sort by severity: Critical / High / Medium / Low.
+
+Each item must include:
+
+- **Changed token** — the symbol / path / command / rule name that triggered the check, and the direction (added / removed / renamed / signature-changed)
+- **Stale location(s)** — file and line numbers of surviving references (or the missing-consumer site, for end-to-end gaps)
+- **Description** — what is inconsistent, in one or two sentences
+- **Impact** — what breaks, or what misleads, because of this
+- **Severity** — Critical / High / Medium / Low
+- **Scope note** — if the gap falls inside a `## Out of scope` area of the plan, say so and recommend adjusting scope or completing the feature
+
+End with a summary:
+
+- Total issues by severity
+- Count of `## Out of scope` violations (subset of the above)
+- Informational items (no action needed)


### PR DESCRIPTION
## Summary
`/hq:start` Phase 7 を diff 種別 (code / doc / mixed) を前段で判定して起動 agent を可変化する設計に刷新する。新設の `integrity-checker` agent が下流参照 / scope boundary / end-to-end 整合性を常時検査し、code-reviewer / security-scanner では構造的に拾えない half-shipped パターンを補完する。`security-scanner` は pattern detection 主体のため model を sonnet → haiku に降格。

## Changes
- `plugin/v2/skills/integrity-check/SKILL.md` 新設 — Review Criteria (下流参照整合性 / scope boundary integrity / end-to-end feature completeness)、Extraction Targets、Severity、Reporting Format、Project Overrides (`.hq/integrity-check.md`) を定義
- `plugin/v2/agents/integrity-checker.md` 新設 — `code-reviewer.md` と同構造、model: sonnet、Phase 7 で常時並列起動
- `plugin/v2/agents/security-scanner.md` を model: haiku に変更、本文に降格理由を記述
- `plugin/v2/commands/start.md` に `## Diff Classification` セクションを挿入 — 拡張子ベースの分類ルール (Markdown 系 / Office / OpenDocument / Google Docs / iWork / Portable の 6 グループ)、bash 1-liner、Agent launch マトリクスを定義。Phase 6 / Phase 7 を diff 種別分岐型に書き換え。Phase 10 Report も新マトリクス反映
- `plugin/v2/skills/bootstrap/templates/workflow.md` `## Quality Review` を Step 1 (Classify the diff) / Step 2 (Launch by matrix) / Step 3 (Fix FB Issues) の 3 ステップ構成に再編し、FB 生成 agent を明示
- `plugin/v2/docs/workflow.md` の Phase 6 / 7 図を 3 agent + diff 種別分岐構成に更新、Key decisions に「Diff-kind aware Phase 6 / Phase 7」「Integrity is its own agent」を追加
- `README.md` skills 表に `integrity-check`、agents 表に `integrity-checker` を追加。Phase 7 の diff-kind aware 挙動を要約。Key differences from v1 を 3 agent 表記に更新
- `.claude-plugin/plugin.json` の agents 配列に `integrity-checker.md` を登録

## Manual Verification
- [ ] [manual] 新ブランチで `/hq:start` をコード変更 diff と doc-only diff の両方で実行し、前者では 3 agent 並列起動・後者では `code-reviewer` + `integrity-checker` のみ起動することを実地確認する
- [ ] [manual] `integrity-checker` agent が PR #19 / #18 相当の half-shipped パターン (下流参照未更新) を検出して FB を出力することを、代表的な diff を用意して実地確認する

Closes #21
Refs #20