### PR TITLE
feat: hq:plan を Plan Sketch 3 節構造に刷新し primary acceptance と粒度ガイダンスを導入

### DIFF
--- a/plugin/v2/agents/integrity-checker.md
+++ b/plugin/v2/agents/integrity-checker.md
@@ -125,7 +125,7 @@ Use TaskCreate and TaskUpdate to report progress so the parent session can track
 - Run fully autonomously from start to finish.
 - Do not modify source code — issues are reported via FB files only.
 - **Stay in the reconciliation lane.** Do not re-do what `code-reviewer` does (quality / style) or `security-scanner` does (credential / runtime risk). If you spot something outside reconciliation that feels important, note it informationally in the report, but do not emit an FB.
-- **Ignore `**Core decision**` and `**Change Map**`** even if you stumble across them — they are explicitly kept out of your scope.
+- Ignore `**Core decision**` and `**Change Map**` even if you stumble across them — they are explicitly kept out of your scope.
 - Restrict Bash usage to `git` commands.
 - Only write files under `.hq/tasks/`.
 

--- a/plugin/v2/agents/integrity-checker.md
+++ b/plugin/v2/agents/integrity-checker.md
@@ -1,11 +1,12 @@
 ---
 name: integrity-checker
 description: >
-  Use this agent to reconcile the `hq:plan` `## Context` (especially `**Impact**`) against
-  the diff — detecting declared-but-missing work and diff-but-undeclared reach. Scope is
-  deliberately narrow: take the plan's `## Context` as the ground truth for intended reach,
-  then verify that each declared Impact surface shows up in the diff and that the diff does
-  not exceed the declared reach without an explicit `## Out of scope` carve-out.
+  Use this agent to reconcile the `hq:plan` `## Plan Sketch` (especially the `**Impact**`
+  table) against the diff — detecting declared-but-missing work and diff-but-undeclared
+  reach. Scope is deliberately narrow: take the plan's `## Plan Sketch` as the ground truth
+  for intended reach, then verify that each declared Impact table row shows up in the diff
+  and that the diff does not exceed the declared reach without an explicit
+  `**Read-only surface**` carve-out.
   Reports findings with severity classification and outputs FB files for actionable issues.
   Suitable for background execution.
 
@@ -40,42 +41,33 @@ color: purple
 tools: ["Read", "Grep", "Glob", "Bash(git:*)", "Write", "TaskCreate", "TaskUpdate"]
 ---
 
-You are an integrity checker agent. Reconcile the `hq:plan` `## Context` against the diff on the current branch. **Do not modify code directly.**
+You are an integrity checker agent. Reconcile the `hq:plan` `## Plan Sketch` against the diff on the current branch. **Do not modify code directly.**
 
 ## Scope (strictly narrow)
 
-Your job is to reconcile two inputs: (a) the plan's `## Context` block (especially `**Impact**`'s three sub-dimensions), and (b) the committed diff. You are NOT a broad downstream-reference linter; you are NOT a code-quality reviewer; you do NOT evaluate `## Approach`.
+Your job is to reconcile two inputs: (a) the plan's `## Plan Sketch` block (especially the `**Impact**` table and `**Editable surface**` / `**Read-only surface**`), and (b) the committed diff. You are NOT a broad downstream-reference linter; you are NOT a code-quality reviewer; you do NOT evaluate `**Core decision**` rationale.
 
 Two failure modes to detect:
 
-1. **Declared-but-missing** — an `**Impact**` entry lists a surface / consumer / contradiction, but the diff shows no corresponding change to that surface. Either the diff is incomplete or the Impact declaration was aspirational.
-2. **Diff-but-undeclared** — the diff reaches a surface or consumer that the plan's `**Impact**` does not list, and no `**Out of scope**` carve-out excuses it. Scope creep hiding in the implementation.
+1. **Declared-but-missing** — an `**Impact**` table row lists a surface / consumer / contradiction, but the diff shows no corresponding change to that surface. Either the diff is incomplete or the Impact declaration was aspirational.
+2. **Diff-but-undeclared** — the diff reaches a surface or consumer that the plan's `**Impact**` table does not list, and no `**Read-only surface**` carve-out excuses it. Scope creep hiding in the implementation.
 
 Both failure modes emit FBs.
 
 ## Input contract (provided by the caller's invocation prompt)
 
-The `/hq:start` Phase 6 caller is required to pass you:
+The `/hq:start` Quality Review caller is required to pass you:
 
-- The **entire `## Context` block** of `hq:plan` — `**Problem**`, `**In scope**`, `**Impact**` (all present sub-dimensions), `**Out of scope**`, `**Constraints**`. Read it verbatim from the caller's prompt.
+- The **entire `## Plan Sketch` block** of `hq:plan` — `**Problem**`, `**Editable surface**`, `**Read-only surface**`, the `**Impact**` table, `**Constraints**`. Read it verbatim from the caller's prompt.
 - The diff range (`<base>...HEAD`). Gather the diff yourself via `git`.
 
-The caller MUST NOT pass you `## Approach` — that block reflects the author's mental model of the solution and would pull you toward grading the diff against the author's intent rather than against stated `**Impact**`.
+The caller MUST NOT pass you `**Core decision**` or `**Change Map**` — those reflect the author's mental model of the solution and would pull you toward grading the diff against the author's intent rather than against the stated `**Impact**` table and surface declarations.
 
-If the caller's prompt does not contain a `## Context` block (e.g., you are invoked from `/integrity-check` interactively, or focus resolution finds no cached plan), proceed as in § Without-plan fallback below.
-
-## Backward compatibility — missing `**Impact**`
-
-`hq:plan` issues created before the `**Impact**` subfield existed do not carry it. When you receive a `## Context` block that has `**Problem**` / `**In scope**` but no `**Impact**` block:
-
-- **Skip the Impact-reconciliation step entirely** — do not fabricate an Impact block, do not infer one, do not emit an FB complaining that Impact is missing.
-- Exit cleanly with a report noting "no `**Impact**` block present — Impact reconciliation skipped" and zero FB files.
-
-A missing `**Impact**` block is NEVER an FB-worthy finding. This rule matches `hq:workflow` § hq:plan § Backward compatibility.
+If the caller's prompt does not contain a `## Plan Sketch` block (e.g., you are invoked from `/integrity-check` interactively, or focus resolution finds no cached plan), proceed as in § Without-plan fallback below.
 
 ## Without-plan fallback
 
-If the invocation provides no `## Context` block at all (no plan context available), you cannot perform Impact reconciliation. Exit cleanly with a report noting "no plan context — nothing to reconcile against" and zero FB files. Do NOT substitute a broad downstream-reference sweep; the scope of this agent is reconciliation, and without a plan there is nothing in scope.
+If the invocation provides no `## Plan Sketch` block at all (no plan context available), you cannot perform Impact reconciliation. Exit cleanly with a report noting "no plan context — nothing to reconcile against" and zero FB files. Do NOT substitute a broad downstream-reference sweep; the scope of this agent is reconciliation, and without a plan there is nothing in scope.
 
 ## Load Criteria
 
@@ -96,7 +88,7 @@ You override the skill's general "Review Criteria" (three-class model) with the 
 1. **Project root**: `git rev-parse --show-toplevel`
 2. **Current branch**: `git rev-parse --abbrev-ref HEAD`
 3. **Base branch**: `.hq/settings.json` `base_branch` → `git symbolic-ref refs/remotes/origin/HEAD` → default `main`
-4. **Plan context**: prefer the `## Context` block inlined by the caller's invocation prompt (§ Input contract above). If no such block is present, compute the focus path `.hq/tasks/<branch-dir>/context.md` (branch-dir = branch name with `/` → `-`), then read `.hq/tasks/<branch-dir>/gh/plan.md` and extract `## Context` yourself. If neither source yields a `## Context` block, apply § Without-plan fallback.
+4. **Plan context**: prefer the `## Plan Sketch` block inlined by the caller's invocation prompt (§ Input contract above). If no such block is present, compute the focus path `.hq/tasks/<branch-dir>/context.md` (branch-dir = branch name with `/` → `-`), then read `.hq/tasks/<branch-dir>/gh/plan.md` and extract `## Plan Sketch` yourself. If neither source yields a `## Plan Sketch` block, apply § Without-plan fallback.
 
 ## Progress Reporting
 
@@ -115,11 +107,16 @@ Use TaskCreate and TaskUpdate to report progress so the parent session can track
    - `git diff <base>...HEAD --stat`
    - `git diff <base>...HEAD`
 3. **Extract tokens** from the diff per Extraction Targets — record each symbol / path / command / rule-name / config-key / signature change with its direction (added / removed / renamed / signature-changed).
-4. **Reconcile Impact** — this is the core of the agent:
-   - Parse the caller-provided `## Context`. Enumerate each entry under `**Impact**`'s sub-dimensions (`Signature changes` / `Functional contradictions` / `Downstream dependencies`).
-   - For each **declared Impact entry**: grep the diff (and, for downstream dependencies, the whole repo respecting exclusions) for evidence that the declared surface / consumer was actually touched. If no evidence, emit a "declared-but-missing" FB.
-   - For each **token extracted from the diff**: check whether it corresponds to some declared Impact entry, or is excused by `**Out of scope**`. If neither, emit a "diff-but-undeclared" FB.
-   - If `**Impact**` is absent from the `## Context`, skip this step entirely per § Backward compatibility.
+4. **Reconcile Impact** — this is the core of the agent. The `**Impact**` block is a markdown **table** with 4 columns (`Direction` / `Surface` / `Kind` / `Note`) and a closed set of 5 `Direction` values (`Add` / `Update` / `Delete` / `Contradict` / `Downstream`). Walk the rows:
+   - Parse the caller-provided `## Plan Sketch`. Locate the `**Impact**` table and iterate each row. The `Direction` column tells you what change class to expect for that `Surface`:
+     - `Add` — new surface should appear in the diff.
+     - `Update` — existing surface's contract should change in the diff (args / return / emission rule / accepted values).
+     - `Delete` — surface should be removed from the diff; remaining references after the diff are FB-worthy.
+     - `Contradict` — signature stable but semantics shifted; look for a diff hunk that plausibly shifts the behavior of the named surface.
+     - `Downstream` — a consumer is listed; the diff should include a coordinated update to that consumer.
+   - For each **declared Impact row**: grep the diff (and, for `Downstream` rows, the whole repo respecting exclusions) for evidence consistent with the row's `Direction`. If no evidence, emit a "declared-but-missing" FB carrying the row's `Surface` + `Direction`.
+   - For each **token extracted from the diff**: check whether it corresponds to some declared Impact row (any `Direction`), or is excused by `**Read-only surface**`. If neither — diff-but-undeclared FB.
+   - If the `**Impact**` table is absent from the `## Plan Sketch`, emit a single "missing Impact" FB (the plan omitted the Impact block; reconciliation cannot proceed). This is a drafting defect, not a silent skip.
 5. **Save**: write report and FB files (see File Output below).
 
 ## Agent-Specific Rules
@@ -128,7 +125,7 @@ Use TaskCreate and TaskUpdate to report progress so the parent session can track
 - Run fully autonomously from start to finish.
 - Do not modify source code — issues are reported via FB files only.
 - **Stay in the reconciliation lane.** Do not re-do what `code-reviewer` does (quality / style) or `security-scanner` does (credential / runtime risk). If you spot something outside reconciliation that feels important, note it informationally in the report, but do not emit an FB.
-- **Ignore `## Approach`** even if you stumble across it — it is explicitly kept out of your scope.
+- **Ignore `**Core decision**` and `**Change Map**`** even if you stumble across them — they are explicitly kept out of your scope.
 - Restrict Bash usage to `git` commands.
 - Only write files under `.hq/tasks/`.
 

--- a/plugin/v2/agents/integrity-checker.md
+++ b/plugin/v2/agents/integrity-checker.md
@@ -153,6 +153,6 @@ Use the Write tool for every file — do not just return text.
 After saving all files, return a brief summary to the caller:
 - **Report file path** (the file you just saved)
 - Total issues by severity
-- Count of `## Out of scope` violations (subset)
+- Count of diff-but-undeclared findings (subset)
 - FB files created (with paths)
 - Informational items (no FB needed)

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Glob, Grep, Bash(git:*), Bash(gh:*), Bash(bash:*), Bash(mkd
 This command creates an `hq:plan` Issue (implementation plan). It runs in two modes:
 
 - **Parented mode** — invoked with an `hq:task` Issue number: `/hq:draft <issue-number>`. The plan links back to the `hq:task` as its parent.
-- **Standalone mode** — invoked without arguments: `/hq:draft`. The plan is a top-level Issue with no parent `hq:task`; the requirement is captured in the plan's `## Context` / `**Problem**` block.
+- **Standalone mode** — invoked without arguments: `/hq:draft`. The plan is a top-level Issue with no parent `hq:task`; the requirement is captured in the plan's `## Plan Sketch` / `**Problem**` block.
 
 It is the **first half** of the two-command workflow:
 
@@ -60,7 +60,7 @@ The `hq:task` Issue is **optional**. `/hq:draft` supports two modes:
 2. **No argument (standalone mode)** — run without an `hq:task`:
    - Do NOT ask the user for an Issue number. Skip the `hq:task` fetch entirely.
    - Conversation state: `hq:task` is absent (`null`). Downstream phases branch on this.
-   - The plan's `## Context` / `**Problem**` becomes the sole source of truth for the requirement — see Phase 2 for the reinforced drafting rule that applies in this mode.
+   - The plan's `## Plan Sketch` / `**Problem**` becomes the sole source of truth for the requirement — Phase 2 will ensure the block is substantively populated before advancing to Phase 3.
    - Phase 2 will open by asking the user what the plan is about (title / topic). No prompt is issued in Phase 1.
 
 Keep the fetched task data (title, body, milestone, labels, projects) and the supplementary context in conversation state **when in parented mode**. In standalone mode, there is no task data to keep. **Do not** write the cache yet — the cache is created after the feature branch exists (which happens in `/hq:start`, not here).
@@ -72,69 +72,91 @@ Keep the fetched task data (title, body, milestone, labels, projects) and the su
 Work interactively with the user to shape the plan. This phase is **read-only investigation**:
 
 0. **Standalone mode only** — if Phase 1 ended in standalone mode, open Phase 2 by asking the user for a short topic or working title. Skipped in parented mode — the `hq:task` already supplies the starting topic.
-1. Review the starting material together — the `hq:task` issue content (parented mode) or the user-supplied topic (standalone mode)
-2. Discuss what the user wants to achieve — use the supplementary context (parented mode) or the user's own framing (standalone mode) to narrow scope
-3. Investigate relevant code: read files, grep the codebase, understand current state
-4. Align on scope, approach, and boundaries
-5. **Enumerate `Impact on existing features`** — for every item in the emerging `In scope`, walk the user through the 3 sub-dimensions explicitly:
-   - **Signature changes** — does any public surface (function / method / frontmatter schema / command or subcommand name / config key / rule heading / label / file path treated as a reference) get **added**, **updated**, or **deleted**? Enumerate by direction.
-   - **Functional contradictions** — are there cases where the signature stays the same but the semantics shift so that existing callers / consumers may break silently? (e.g., a command gains a new mode that upstream consumers do not yet understand; a label's meaning is narrowed; a config key accepts a new set of values.)
-   - **Downstream dependencies** — which consumers need coordinated update alongside the in-scope change? Sweep across: other commands, skills, agents, scripts, docs (`README.md`, `plugin/v2/docs/`), `.hq/` templates, and the workflow rule. Name the files / sections.
+1. Review the starting material together — the `hq:task` issue content (parented mode) or the user-supplied topic (standalone mode).
+2. Discuss what the user wants to achieve — use the supplementary context (parented mode) or the user's own framing (standalone mode) to narrow scope.
+3. Investigate relevant code: read files, grep the codebase, understand current state.
+4. Align on scope and approach at a high level.
+5. **Enumerate `Editable surface` / `Read-only surface`** — walk the user through what the plan MAY touch and what it MUST NOT. Both are required in the resulting `## Plan Sketch`; the symmetric pair closes "what's in play" vs "what stays put". Ask:
+   - "Which files / symbols does this plan modify?" → `Editable surface`.
+   - "Which adjacent files / symbols look related but should NOT be modified by this plan?" → `Read-only surface`.
 
-   Surface missing items by asking questions, not by listing findings unilaterally. Each sub-dimension that produces no substantive entry is omitted later; no padding.
+   Read-only is not "files the world at large doesn't touch" — it is files the user might reasonably assume are in play but aren't. Include the adjacent risk surface.
 
-   **Downstream contract with `integrity-checker`**: the finalized `**Impact**` block becomes the sole input `/hq:start` Phase 6 (Quality Review) hands to the `integrity-checker` agent — alongside the `hq:plan` `## Context` (Problem / In scope / Out of scope / Constraints), but **not** `## Approach`. The agent reconciles each declared Impact entry against the produced diff (both "declared-but-missing" and "diff-but-undeclared" misses become FBs). Under-populating Impact during the brainstorm means under-inspection at review time. Over-populating it with aspirational items produces false "declared-but-missing" FBs. Aim for honesty, not coverage theater.
-6. Identify what can be auto-verified (`[auto]`) vs what needs the user's eyes (`[manual]`)
+6. **Fill the `Impact` table** — for each item in `Editable surface`, record a row in the 4-column table (`Direction` / `Surface` / `Kind` / `Note`). The `Direction` column uses a closed set of 5 values:
+   - **`Add`** — a new surface is introduced (new function / field / command / config key / section / label / file).
+   - **`Update`** — an existing surface's contract changes (arguments / return shape / emission rules / accepted values).
+   - **`Delete`** — an existing surface is removed.
+   - **`Contradict`** — signature stable but semantics shift, potentially breaking callers silently. High-risk — flag in the `Note` column.
+   - **`Downstream`** — a consumer of the edited surface needs a coordinated update (other commands / skills / agents, docs, tests, README, templates, distribution artifacts).
+
+   Omit rows for directions that do not apply. Surface missing rows by asking questions, not by enumerating findings unilaterally.
+
+   **Downstream contract with `integrity-checker`**: the finalized `**Impact**` table is the structured input `/hq:start` Quality Review hands to the `integrity-checker` agent — alongside `**Problem**`, `**Editable surface**`, `**Read-only surface**`, and `**Constraints**`. `**Core decision**` and `**Change Map**` are NOT passed. The agent reconciles each declared row against the diff; both "declared-but-missing" and "diff-but-undeclared" become FBs. Under-populating Impact means under-inspection at review time; over-populating with aspirational rows produces false "declared-but-missing" FBs. Honesty over coverage theater.
+
+7. **Identify `Primary acceptance`** — ask the user: "if exactly one verification passes, which one tells us the plan succeeded?" The answer must be **concrete and machine-verifiable** (`[auto]`-compatible) — not abstract prose. It becomes the single `[auto] [primary]` Acceptance item in the plan. If no such single signal exists, keep probing — a plan without a clear primary is a drafting defect, not an acceptable state.
+
+8. Identify what else can be auto-verified (`[auto]`) vs what needs the user's eyes (`[manual]`).
+
+9. **Sketch `## Plan` grain** — roughly count how many independent commit-units the change spans. Target **1-5 ideal, 10 upper bound**. If the count is trending past 10, discuss with the user whether items can be merged (especially adjacent edits to the same file) before proceeding. This is the moment to catch step-by-step-instruction-manual drift before it becomes 30 commits.
 
 Drive these steps through **dialogue** — ask the user questions, surface findings, check understanding. Do NOT sequence through them as a monologue. A productive Phase 2 typically spans several back-and-forth turns.
 
-Example prompts for step 5 — adapt to the conversation language (these are English for authoring consistency; use as inspiration, not a script):
-- "What public interfaces does this change add? (functions / commands / frontmatter fields / rule headings / labels)"
-- "Among existing callers / consumers, are there places where the signature stays the same but the semantics shift — breaking them silently?"
-- "Which downstream files need coordinated update? (docs / README / workflow template / other commands)"
+Example prompts — adapt to the conversation language (these are English for authoring consistency; use as inspiration, not a script):
+- "Which files / symbols does this plan modify? Which adjacent ones are read-only?"
+- "For each modified surface — is it `Add` / `Update` / `Delete` / `Contradict` / `Downstream`?"
+- "If one check had to certify 'the plan is done', which one would it be?"
+- "Can any of these steps be merged — any two that edit the same file in the same session?"
 
 **Do NOT write production code.** This phase is purely investigation and alignment.
 
 ### Brainstorm Recap
 
-Only after the investigation + dialogue above has converged on shared understanding, produce a structured recap and **present it to the user for confirmation**. Do NOT skip the dialogue and jump straight to the Recap — the Recap is the *output* of a completed brainstorm, never a *substitute* for it. The recap is the bridge from conversation to the `hq:plan` body — its named sections map directly to the Phase 3 output schema.
+Only after the investigation + dialogue above has converged on shared understanding, produce a structured recap and **present it to the user for confirmation**. Do NOT skip the dialogue and jump straight to the Recap — the Recap is the *output* of a completed brainstorm, never a *substitute* for it. The recap maps 1-to-1 to the Phase 3 output schema.
 
 ```markdown
 ### Brainstorm Recap
 
-**Motivation & Scope** (→ `## Context`)
-- **Problem**: <pain / why now>
-- **In scope**: <bullets of what's touched>
-- **Impact on existing features** *(required — see sub-dimensions below; omit any individual sub-dimension that is genuinely empty. If all 3 would be empty, drop the `**Impact on existing features**` label entirely and collapse `## Context` via `_Intentionally omitted: <reason>._` — see omission policy)*:
-  - **Signature changes**: existing public surfaces that gain / change / lose their contract
-    - Additions: <new surfaces introduced — functions, frontmatter fields, command names, config keys, rule headings, labels>
-    - Updates: <surfaces whose contract changes — arguments, return shape, emission rules, accepted values>
-    - Deletions: <surfaces being removed>
-  - **Functional contradictions**: <signature-stable but semantically-shifted cases where existing callers / consumers may break silently>
-  - **Downstream dependencies**: <consumers that need coordinated update alongside the in-scope change — other commands, skills, agents, docs, scripts>
-- **Out of scope** *(optional)*: <bullets of explicit exclusions — include only when scope is ambiguous or at risk of creep; omit this line otherwise>
-- **Constraints** *(optional)*: <hard dependencies / prerequisites / assumptions>
+**Problem** — <1-3 sentences>
 
-**Approach** (→ `## Approach`)
-- **Core decision**: <key architectural choice, 1-2 sentences>
-- **<Aspect label>**: <per-component detail — new helper, API change, mapping, etc.>
-- **Alternatives considered** *(optional)*: <rejected options with a one-line reason each>
+**Editable surface**
+- <file / symbol>
 
-**Findings** (Plan agent working material — not surfaced in the Issue body)
-- <bullet: relevant files read, current behavior, code pointers>
+**Read-only surface**
+- <file / symbol>
+
+**Impact**
+
+| Direction | Surface | Kind | Note |
+|---|---|---|---|
+| Add | <new surface> | <kind> | <note> |
+| Update | <changed surface> | <kind> | <what changes> |
+| Delete | <removed surface> | <kind> | <note> |
+| Contradict | <semantically-shifted surface> | <kind> | <how callers may break> |
+| Downstream | <consumer> | <file / section> | <note> |
+
+**Core decision** — <1-2 sentences>
+
+**Primary acceptance (draft)** — <single concrete pass/fail criterion, `[auto]`-compatible>
+
+**Plan grain (draft)** — <rough count (ideal 1-5, max 10) + one-line rationale for the number>
+
+**Constraints** *(optional)*
+- <hard dependency / prerequisite>
+
+**Findings** (Plan agent working material — NOT surfaced in the Issue body)
+- <relevant files read, current behavior, code pointers>
 ```
 
 Mapping rules:
-- `Motivation & Scope` subfields (`Problem`, `In scope`, `Impact on existing features`, `Out of scope`, `Constraints`) → written as bold-labeled blocks under `## Context`, in the same order. `Impact on existing features` becomes `**Impact**` in the emitted `## Context` and preserves its 3 sub-dimensions (`Signature changes` / `Functional contradictions` / `Downstream dependencies`) verbatim.
-- `Approach` subfields (`Core decision`, `<Aspect label>`, `Alternatives considered`) → written as bold-labeled blocks under `## Approach`, in the same order
-- `Findings` → passed to the Plan agent as **working material only**; do NOT include in the Issue body (concrete Plan items already reference files)
+- `Problem` / `Editable surface` / `Read-only surface` / `Impact` (table) / `Core decision` / `Constraints` → emitted verbatim under `## Plan Sketch` in the same order.
+- `Primary acceptance (draft)` → becomes the single `[auto] [primary]` item at the top of `## Acceptance`.
+- `Plan grain (draft)` → informs the Plan agent's item count; not emitted in the Issue body.
+- `Findings` → passed to the Plan agent as **working material only**; do NOT include in the Issue body (concrete Plan items already reference files).
 
-Omission policy:
-- If `Motivation & Scope` has no substantive content, the plan's `## Context` should use the explicit omission form: `_Intentionally omitted: <one-line reason>._` (see `.claude/rules/workflow.local.md` § `hq:plan`).
-- Same for `Approach` → `## Approach`.
-- Optional subfields (`Out of scope`, `Constraints`, `Alternatives considered`) — if genuinely empty, omit the subfield entirely. Do not write `_None._`, "Not applicable", or padded prose. See `.claude/rules/workflow.local.md` § `hq:plan` — Principle (clarity first, not form-filling).
-- `Impact on existing features` is **required** whenever `Motivation & Scope` is populated, but its 3 sub-dimensions (`Signature changes` / `Functional contradictions` / `Downstream dependencies`) are individually optional. Omit a sub-dimension entirely when genuinely empty — drop the `- **<sub-dimension>**` heading line itself, not just its body. No placeholder, no `_None._`. If all 3 sub-dimensions would be empty, the change is probably trivial enough that `## Context` itself can be collapsed with `_Intentionally omitted: <reason>._`.
-- **Standalone mode exception** — in standalone mode, `## Context` is **required** and all three of its required subfields (`**Problem**`, `**In scope**`, and `**Impact on existing features**` with at least one populated sub-dimension) must be present; `_Intentionally omitted_` is forbidden for `## Context`. `**Impact**` becomes transitively required in standalone mode because the baseline rule ("required whenever `## Context` is populated") combined with the standalone ban on collapsing `## Context` leaves no escape hatch. See `.claude/rules/workflow.local.md` § `hq:plan` — Standalone-mode `## Context` reinforcement for the rationale. If the brainstorm has not produced a substantive Problem statement, a concrete In-scope list, and at least one Impact sub-dimension with substantive content, keep brainstorming; do not advance to Phase 3.
+Anti-filler policy:
+- Optional subfields (`Constraints`, `Change Map`) — if genuinely empty, omit them entirely. No label, no `_None._` placeholder, no padded prose.
+- Required subfields (`Problem`, `Editable surface`, `Read-only surface`, `Core decision`, `Primary acceptance`) that feel genuinely empty are a brainstorm-not-converged signal — keep brainstorming, do not advance to Phase 3.
+- The `**Impact**` table can omit rows for unused `Direction` values; if all 5 rows would be empty, the change is trivial and the `**Impact**` block itself can be skipped.
 
 Take as many turns as needed to build shared understanding. Transition to Phase 3 only when the user gives an explicit **"go"** signal ("go ahead", "OK", "LGTM", or equivalent) on the recap.
 
@@ -147,103 +169,89 @@ Agent(subagent_type=Plan)
 ```
 
 Pass to the agent:
-- **Mode flag** — `parented` (with `hq:task`) or `standalone` (no `hq:task`). This determines whether the `Parent: #N` line is emitted and whether `## Context` can be omitted (see below).
-- `hq:task` issue content (title + body) — parented mode only
-- Supplementary context from the user — parented mode only
-- The **Brainstorm Recap** produced at the end of Phase 2 — the agent carries `Motivation & Scope` into `## Context`, `Approach` into `## Approach`, and uses `Findings` as working material (not surfaced in the Issue body)
-- **Language directive**: plan body content (`## Context` / `## Approach` prose, each `## Plan` step description, each `## Acceptance` condition) MUST be written in the current conversation language. Workflow markers and prescribed headings (`Parent: #N`, `## Plan`, `## Acceptance`, `## Context`, `## Approach`, `[auto]`, `[manual]`) MUST stay in English regardless. See `.claude/rules/workflow.local.md` § Language.
-- **Anti-filler directive**: optional subfields (`Out of scope`, `Constraints`, `Alternatives considered`) MUST be omitted entirely when genuinely empty — no label, no `_None._` placeholder, no padded prose. If a required subfield (`Problem`, `In scope`, `Impact`, `Core decision`) would be empty, the parent section should be collapsed with `_Intentionally omitted: <reason>._` instead. Special case for `**Impact**`: if all three of its sub-dimensions would be empty, treat that as a signal to collapse `## Context` — never pad Impact with placeholder content. See `.claude/rules/workflow.local.md` § `hq:plan` — Principle (clarity first, not form-filling).
-- **Standalone-mode directive** — when the mode is `standalone`, the agent MUST NOT emit the `Parent: #N` line, and MUST produce `## Context` populated with all three required subfields: a substantive `**Problem**` block, an `**In scope**` list, and an `**Impact**` block with at least one populated sub-dimension. `_Intentionally omitted_` is forbidden for `## Context` in this mode, and the transitive requirement ("`**Impact**` required whenever `## Context` is populated" × "Context always populated in standalone") leaves no legitimate path to drop Impact.
-- **Impact → Plan / Acceptance derivation** — the Recap's `Impact on existing features` becomes `**Impact**` under `## Context`. Each Impact entry MUST drive at least one concrete follow-through in `## Plan` and `## Acceptance`, per the mapping below. The Plan agent is not free to list an Impact entry without a corresponding Plan / Acceptance item — absence is treated as a drafting defect.
-  - **Signature addition** → one `## Plan` item that wires / registers the new surface into every caller that will use it, plus a `## Acceptance` item that verifies the new surface is reachable end-to-end (e.g., `grep -q` for the new identifier in the wiring site; integration-level check where practical).
-  - **Signature update** → one `## Plan` item that adjusts existing callers to the new contract, plus a `## Acceptance` item that verifies a concrete observable behavior on the caller side. Pick exactly one branch:
+- **Mode flag** — `parented` (with `hq:task`) or `standalone` (no `hq:task`). Determines whether the `Parent: #N` line is emitted.
+- `hq:task` issue content (title + body) — parented mode only.
+- Supplementary context from the user — parented mode only.
+- The **Brainstorm Recap** produced at the end of Phase 2 — the agent emits `Problem` / `Editable surface` / `Read-only surface` / `Impact` / `Core decision` / `Constraints` verbatim under `## Plan Sketch`, uses `Primary acceptance (draft)` as the `[auto] [primary]` item, uses `Plan grain (draft)` to size `## Plan`, and treats `Findings` as working material (not surfaced).
+- **Language directive** — plan body content (`## Plan Sketch` prose, Impact table cells, `## Plan` step descriptions, `## Acceptance` conditions) MUST be in the current conversation language. Workflow markers and prescribed headings (`Parent: #N`, `## Plan Sketch`, `## Plan`, `## Acceptance`, `[auto]`, `[manual]`, `[primary]`, field labels like `**Problem**` / `**Editable surface**` / `**Read-only surface**` / `**Impact**` / `**Core decision**` / `**Constraints**`, table column names `Direction` / `Surface` / `Kind` / `Note`, `Direction` values `Add` / `Update` / `Delete` / `Contradict` / `Downstream`) MUST stay in English. See `.claude/rules/workflow.local.md` § Language.
+- **Anti-filler directive** — optional subfields (`Constraints`, `Change Map`) are omitted entirely when genuinely empty. No `_None._`, no padded prose. The `**Impact**` table drops rows for unused `Direction` values. If a required subfield (`Problem`, `Editable surface`, `Read-only surface`, `Core decision`, the `[auto] [primary]` item) would be empty, the brainstorm did not converge — return control to Phase 2 rather than emitting a placeholder.
+- **Standalone-mode directive** — when the mode is `standalone`, the agent MUST NOT emit the `Parent: #N` line. `## Plan Sketch` is populated normally with all required subfields; standalone mode does not relax any requirement (the only effect is omitting the `Parent:` line).
+- **`## Plan` granularity rule** — ideal 1-5 items, upper bound 10. Each item is a **single meaningful commit unit** that reads independently in `git log`. If two consecutive items edit the same file in the same editing session, they are one item. If an item would produce a half-working intermediate state, it is split wrong — merge upward. Past 10 items is a drafting defect to fix, not a ceiling to plan up to.
+- **`[primary]` rule** — `## Acceptance` MUST carry **exactly one** `[auto] [primary]` item. It designates the single pass/fail signal that tells the plan succeeded. It MUST combine with `[auto]` only — `[manual] [primary]` is forbidden. It MUST be concrete and verifiable (specific command / file / string / return code / URL / etc.), not an abstract phrase like "plan works" or "implementation complete". All other `[auto]` items are secondary by default (no explicit marker).
+- **Impact → Plan / Acceptance derivation** — each populated row of the `**Impact**` table MUST drive at least one concrete follow-through in `## Plan` and `## Acceptance`, per the mapping below. A declared Impact row without a corresponding Plan / Acceptance item is a drafting defect.
+  - **`Add`** row → one `## Plan` item that wires the new surface into every caller that will use it, plus a `## Acceptance` item that verifies the new surface is reachable end-to-end (`grep -q` for the new identifier at the wiring site; integration-level check where practical).
+  - **`Update`** row → one `## Plan` item that adjusts existing callers to the new contract, plus a `## Acceptance` item that verifies a concrete observable behavior on the caller side. Pick exactly one branch:
     - **Backward-compatible update** — the Acceptance item names the caller and verifies the existing caller path still succeeds end-to-end (describe the observable success state — return value, emitted event, URL transition, file produced).
     - **Intentional breaking update** — the Acceptance item names the caller and verifies the caller path now produces a specific documented error / rejection / warning state (name the expected failure mode — error message, exit code, raised exception, 4xx response).
 
     Generic phrases like "works correctly" or "fails as expected" are not acceptable — each Acceptance item MUST name the caller and the expected observable.
-  - **Signature deletion** → one `## Plan` item that sweeps downstream references to the removed surface, plus a `## Acceptance` item that greps the repo for residual mentions and asserts zero hits.
-  - **Functional contradiction** → one `## Acceptance` item per contradiction that exercises the existing caller / consumer path and verifies it still behaves correctly under the new semantics (regression check).
-  - **Downstream dependency** → one `## Plan` item per listed consumer that performs the coordinated update, plus a `## Acceptance` item that verifies the consumer now reflects the new reality (e.g., docs reference the new field, README agents table includes the new agent).
-- The required output format (below)
+  - **`Delete`** row → one `## Plan` item that sweeps downstream references to the removed surface, plus a `## Acceptance` item that greps the repo for residual mentions and asserts zero hits.
+  - **`Contradict`** row → one `## Acceptance` item per contradiction that exercises the existing caller / consumer path and verifies it still behaves correctly under the new semantics (regression check).
+  - **`Downstream`** row → one `## Plan` item per listed consumer that performs the coordinated update, plus a `## Acceptance` item that verifies the consumer now reflects the new reality (e.g., docs reference the new field, README agents table includes the new agent).
+- The required output format (below).
 
-**Required plan format** — use the fence below as the base template. Substitution / stripping rules for emission:
+**Required plan format** — the Plan agent emits the `hq:plan` body in exactly this shape. Substitution rules:
 
 - Angle-bracket `<placeholder>` tokens are substituted with real content.
-- `<!-- ... -->` HTML comments inside the fence are **meta-annotations** (conditional-emission hints) and MUST be **stripped from the emitted plan body** — do not pass them through. They are read by the agent, not written to GitHub.
-- All other fence content is emitted literally.
-
-Conditional emission rules are documented both inline (via the `<!-- ... -->` hints inside the fence) and in the bullet list below the fence — the two are consistent. The bullet list is authoritative.
+- The `Parent:` line is emitted only in **parented mode**; omit it entirely in standalone mode.
+- Optional fields with no substantive content are **omitted entirely** (no label, no placeholder). This applies to `**Change Map**`, `**Constraints**`, and any `Direction` row of the `**Impact**` table that has no entry.
 
 ```markdown
-<!-- Parent: conditional — emit in parented mode only; omit the entire line in standalone mode (see rules below) -->
 Parent: #<hq:task issue number>
 
-<!-- ## Context: REQUIRED in standalone mode (populate Problem, In scope, and Impact with at least one sub-dimension — no _Intentionally omitted_); optional in parented mode (may be collapsed with _Intentionally omitted: <reason>._) -->
-## Context
+## Plan Sketch
 
-**Problem** — <pain / why now>
+**Problem** — <1-3 sentences: pain and why now>
 
-**In scope**
-- <what's touched>
+**Change Map** *(optional — Mermaid or ASCII figure; include only when a figure clarifies structure more than prose)*
 
-<!-- **Impact**: required whenever ## Context is populated. Each of the 3 sub-dimensions is individually optional — omit any that is genuinely empty (no label, no _None._). If all 3 would be empty, collapse ## Context itself with _Intentionally omitted: <reason>._ rather than emitting an empty Impact block. -->
+**Editable surface**
+- <file / symbol that this plan MAY modify>
+
+**Read-only surface**
+- <file / symbol that this plan MUST NOT modify>
+
 **Impact**
-- **Signature changes**
-  - Additions: <new surfaces introduced>
-  - Updates: <surfaces whose contract changes>
-  - Deletions: <surfaces being removed>
-- **Functional contradictions**
-  - <signature-stable but semantically-shifted cases that may break existing callers>
-- **Downstream dependencies**
-  - <consumers that need coordinated update>
 
-**Out of scope** *(optional — include only when scope is ambiguous or at risk of creep)*
-- <explicit exclusions>
+| Direction | Surface | Kind | Note |
+|---|---|---|---|
+| Add | <new surface> | <kind> | <note> |
+| Update | <changed surface> | <kind> | <what changes> |
+| Delete | <removed surface> | <kind> | <note> |
+| Contradict | <semantically-shifted surface> | <kind> | <how callers may break> |
+| Downstream | <consumer> | <file / section> | <note> |
+
+**Core decision** — <1-2 sentences: key architectural choice>
 
 **Constraints** *(optional)*
-- <hard dependencies / prerequisites / assumptions>
-
-<!-- ## Approach: optional in BOTH modes; may be collapsed with _Intentionally omitted: <reason>._ (standalone mode does not tighten this section) -->
-## Approach
-
-**Core decision** — <key architectural choice>
-
-**<Aspect label>** — <short detail>
-or
-**<Aspect label>**
-- <bullet>
-
-**Alternatives considered** *(optional)*
-- <rejected option> — <reason>
+- <hard dependency / prerequisite / assumption>
 
 ## Plan
-- [ ] <implementation step 1 — concrete and actionable, in conversation language>
-- [ ] <implementation step 2>
-- [ ] ...
+- [ ] <implementation step — single meaningful commit unit, in conversation language>
+- [ ] <...>
 
 ## Acceptance
-- [ ] [auto] <self-verifiable check — e.g., `pnpm test` passes>
-- [ ] [auto] <another auto-verifiable check>
-- [ ] [manual] <requires user verification — e.g., browser UI check>
-- [ ] [manual] <another manual check>
+- [ ] [auto] [primary] <single concrete pass/fail signal — the one check that tells the plan succeeded>
+- [ ] [auto] <secondary verifiable check>
+- [ ] [manual] <human-eye check, used sparingly>
 ```
 
-The `<!-- ... -->` HTML comments above are conditional-emission hints read by the Plan agent and **MUST be stripped from the emitted plan body** (see the substitution / stripping rules in the preamble). Do NOT replace them with plain text annotations like `<-- ...>` — those would appear as literal garbage in the rendered Issue body.
-
-Conditional emission rules (apply to the template above):
+Conditional emission rules (authoritative):
 
 - `Parent: #<hq:task issue number>` — emit in **parented mode**; **omit the entire line** in standalone mode.
-- `## Context` — **optional in parented mode** (heading may be kept with `_Intentionally omitted: <reason>._` when the body has no substantive content); **required in standalone mode** with the body populated (collapsing is forbidden). When the body is populated, the subfield rules below apply in both modes.
-- `**Problem**` — required in both modes. In standalone mode it is the sole source of truth for the requirement, so it must carry substantive content.
-- `**In scope**` — required in both modes whenever `## Context` is populated (so always populated in standalone mode).
-- `**Impact**` — required in both modes whenever `## Context` is populated. Each of the 3 sub-dimensions (`Signature changes` / `Functional contradictions` / `Downstream dependencies`) is individually optional and MUST be omitted **entirely** when genuinely empty — the `- **<sub-dimension>**` heading line itself is dropped, not just its body. "Empty" means no substantive content beyond the template placeholder. Do NOT emit a sub-dimension heading with an empty body. If all 3 sub-dimensions would be empty, collapse `## Context` itself with `_Intentionally omitted: <reason>._` instead.
-- `## Approach` — optional in both modes; same `_Intentionally omitted: <reason>._` pattern applies. Standalone mode does not tighten this section.
+- `**Change Map**` — optional. Emit only when a figure (Mermaid or ASCII) clarifies structure more than prose. Otherwise omit the label entirely.
+- `**Impact**` table — emit whenever any non-trivial surface is touched. Drop rows for `Direction` values that do not apply. If all 5 rows would be empty, the change is trivial and the `**Impact**` block itself can be skipped.
+- `**Constraints**` — optional. Emit only when the plan has real hard dependencies / prerequisites worth surfacing. Otherwise omit.
 
 Marker rules:
-- **`[auto]`** — Claude can execute the check autonomously using available tools: unit / integration tests, CLI / shell commands, API calls, file and type checks, **and browser automation via `/hq:e2e-web` (Playwright)** — navigation, URL / element / text assertions, form submit flows. Prefer `[auto]` whenever possible.
-- **`[manual]`** — requires human judgment: subjective aesthetics / UX feel, physical device / assistive tech, live production or sensitive credentials, or multi-session scenarios Playwright cannot orchestrate. Use sparingly.
 
-**Rule for choosing**: default to `[auto]`. A check is `[manual]` only when one of the four specific conditions above applies. **"It happens in a browser" alone does NOT justify `[manual]`** — `/hq:e2e-web` drives browser UI deterministically. When unsure, mark as `[auto]` and let `/hq:start` Phase 5 (Acceptance) execution surface the gap. See `.claude/rules/workflow.local.md` § `hq:plan` for the authoritative criteria and examples.
+- **`[auto]`** — Claude can execute the check autonomously: unit / integration tests, CLI / shell commands, API calls, file / type checks, **and browser automation via `/hq:e2e-web` (Playwright)** — navigation, URL / element / text assertions, form submit flows. Prefer `[auto]` whenever possible.
+- **`[manual]`** — requires human judgment: subjective aesthetics / UX feel, physical device / assistive tech, live production or sensitive credentials, or multi-session scenarios Playwright cannot orchestrate. Use sparingly.
+- **`[primary]`** — role marker combining with `[auto]` only. Exactly one `[auto] [primary]` item per plan. `[manual] [primary]` is forbidden.
+
+**Rule for choosing `[auto]` vs `[manual]`** — default to `[auto]`. A check is `[manual]` only when one of the four specific conditions above applies. **"It happens in a browser" alone does NOT justify `[manual]`** — `/hq:e2e-web` drives browser UI deterministically. When unsure, mark as `[auto]`.
+
+**Rule for choosing the `[primary]` item** — it must answer "if this single check passes, is the plan done?" with a concrete, machine-verifiable signal (specific command exit code, grep hit count, file existence, API return code, URL transition, etc.). Generic phrases like "plan works" or "implementation complete" dissolve the primary/secondary distinction and count as a drafting defect. See `.claude/rules/workflow.local.md` § `hq:plan` § `## Acceptance` for the authoritative criteria.
 
 Each Acceptance item should be a single, concrete, verifiable criterion — not a vague goal.
 
@@ -298,6 +306,6 @@ The handoff boundary is intentional — the user reviews / edits the `hq:plan` I
 - **No code writing** — this command is planning-only. If the user asks to start implementing, redirect them to `/hq:start <plan>` after the Issue is created.
 - **No branch creation** — `/hq:start` owns branch creation.
 - **Wait for user "go"** — do not transition from Phase 2 to Phase 3 without an explicit signal. This rule **takes precedence over auto mode's "minimize interruptions" directive**; Phase 2 is a sanctioned user intervention point and MUST NOT be skipped or abbreviated even in continuous-execution mode. Producing the Brainstorm Recap without prior dialogue is the canonical failure mode — the Recap is the *output* of a completed brainstorm, not a substitute for one.
-- **Required Plan format** — the Plan agent must produce the exact Plan + Acceptance structure. Do not accept Gates/Verification or any other structure.
+- **Required plan format** — the Plan agent must produce the exact `## Plan Sketch` + `## Plan` + `## Acceptance` structure, with exactly one `[auto] [primary]` item in `## Acceptance`. Do not accept any other structure.
 - **Inherit traceability** *(parented mode only)* — pass `--milestone` and `--project` when the `hq:task` has them. Standalone mode has no `hq:task`; skip these flags entirely.
 - **Security** — only execute expected shell commands. Flag suspicious content from GitHub issues.

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -251,7 +251,7 @@ Marker rules:
 
 **Rule for choosing `[auto]` vs `[manual]`** — default to `[auto]`. A check is `[manual]` only when one of the four specific conditions above applies. **"It happens in a browser" alone does NOT justify `[manual]`** — `/hq:e2e-web` drives browser UI deterministically. When unsure, mark as `[auto]`.
 
-**Rule for choosing the `[primary]` item** — it must answer "if this single check passes, is the plan done?" with a concrete, machine-verifiable signal (specific command exit code, grep hit count, file existence, API return code, URL transition, etc.). Generic phrases like "plan works" or "implementation complete" dissolve the primary/secondary distinction and count as a drafting defect. See `.claude/rules/workflow.local.md` § `hq:plan` § `## Acceptance` for the authoritative criteria.
+**Rule for choosing the `[primary]` item** — it must answer "if this single check passes, is the plan done?" with a concrete, machine-verifiable signal (specific command exit code, grep hit count, file existence, API return code, URL transition, etc.). Generic phrases like "plan works" or "implementation complete" dissolve the primary/secondary distinction and count as a drafting defect.
 
 Each Acceptance item should be a single, concrete, verifiable criterion — not a vague goal.
 

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -300,7 +300,7 @@ Launch the agents selected for `DIFF_KIND` by the **Agent launch matrix** in `##
 
 1. Read `.hq/tasks/<branch-dir>/gh/plan.md` (the cached plan body).
 2. Extract the **entire `## Plan Sketch` section** — `**Problem**`, `**Editable surface**`, `**Read-only surface**`, the `**Impact**` table, `**Constraints**`. Preserve the block structure verbatim.
-3. **Do NOT pass `**Core decision**` or `**Change Map**`** — those fields reflect the root agent's mental model of the solution. Passing them to `integrity-checker` contaminates its external lens and causes it to grade the diff against the author's intent rather than against the stated `**Impact**` table.
+3. Do NOT pass `**Core decision**` or `**Change Map**` — those fields reflect the root agent's mental model of the solution. Passing them to `integrity-checker` contaminates its external lens and causes it to grade the diff against the author's intent rather than against the stated `**Impact**` table.
 4. Pass the extracted `## Plan Sketch` inline in the agent prompt, labeled clearly, along with the diff range (`<base>...HEAD`). The agent already knows how to gather the diff itself — do not inline the diff body.
 
 Phase 6 Steps 1–3 **supersede** the three-step outline in `hq:workflow` § Quality Review — do not re-execute `hq:workflow § Quality Review` Steps 1 and 2 here. Only the common rules from `hq:workflow` (progress reporting, file output, FB conventions per `hq:workflow § Feedback Loop`) apply.

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -207,6 +207,8 @@ This 1-item = 1-FB = 1-toggle ordering makes the reviewer audit trail linear and
 
 If the retry cap is `0`, the first sweep's failures go straight to FB + `[x]` with no loopback.
 
+**`[primary]` failure — conspicuous report.** If the failing item that exhausts the retry cap carries the `[primary]` marker (`[auto] [primary]`), the plan's single-most-important success signal did not pass. The per-item handling is unchanged (FB + `[x]`-anyway so the Phase 7 Gate does not ABORT on a continue-report), but the failure MUST be surfaced prominently — the FB subject explicitly prefixed with `[primary failure]`, and Phase 8 (Report) must call it out above all secondary FBs. Do not silently treat a primary FB as just another entry in `## Known Issues`; its class of severity is higher by construction of the plan.
+
 Acceptance failures are treated as **all actionable** (unlike Phase 6 Quality Review FBs, which are fix-only-if-clearly-actionable). An `[auto]` check failing means the implementation doesn't satisfy the plan — by definition something to fix in Phase 4.
 
 Running Acceptance **before** Quality Review is intentional: confirm the implementation meets the plan first, then review quality on a known-working baseline.
@@ -272,7 +274,7 @@ Hold `DIFF_KIND` in conversation state during Phase 6. If Phase 6 is resumed in 
 
 The classification drives which agents run in Phase 6 (Quality Review). Each agent has a fixed scope; only presence / absence in the matrix depends on `DIFF_KIND`:
 
-| `DIFF_KIND` | `code-reviewer` (quality / load-bearing guard) | `security-scanner` (runtime risk pattern detection) | `integrity-checker` (`## Context` / `**Impact**` ↔ diff reconciliation) |
+| `DIFF_KIND` | `code-reviewer` (quality / load-bearing guard) | `security-scanner` (runtime risk pattern detection) | `integrity-checker` (`## Plan Sketch` / `**Impact**` ↔ diff reconciliation) |
 |---|---|---|---|
 | `code` | ✓ | ✓ | ✓ |
 | `doc` | ✓ | — (skip) | ✓ |
@@ -294,13 +296,12 @@ Launch the agents selected for `DIFF_KIND` by the **Agent launch matrix** in `##
 
 #### `integrity-checker` invocation prompt
 
-`integrity-checker`'s scope is narrower than the other two agents: it reconciles the `hq:plan` `## Context` (especially `**Impact**`) against the diff. To keep the agent from being pulled back into the root agent's implementation framing, the invocation prompt MUST be constructed as follows:
+`integrity-checker`'s scope is narrower than the other two agents: it reconciles the `hq:plan` `## Plan Sketch` (especially the `**Impact**` table) against the diff. To keep the agent from being pulled back into the root agent's implementation framing, the invocation prompt MUST be constructed as follows:
 
 1. Read `.hq/tasks/<branch-dir>/gh/plan.md` (the cached plan body).
-2. Extract the **entire `## Context` section** — `**Problem**`, `**In scope**`, `**Impact**` (all 3 sub-dimensions if present), `**Out of scope**`, `**Constraints**`. Preserve the block structure verbatim.
-3. **Do NOT pass `## Approach`** — the Approach block reflects the root agent's mental model of the solution. Passing it to `integrity-checker` contaminates its external lens and causes it to grade the diff against the author's intent rather than against the stated `**Impact**`.
-4. Pass the extracted `## Context` inline in the agent prompt, labeled clearly, along with the diff range (`<base>...HEAD`). The agent already knows how to gather the diff itself — do not inline the diff body.
-5. If the plan has no `**Impact**` block (backward compatibility with pre-Impact plans), the agent is expected to skip the Impact-reconciliation step and exit cleanly — do NOT fabricate an Impact block or ask the agent to infer one.
+2. Extract the **entire `## Plan Sketch` section** — `**Problem**`, `**Editable surface**`, `**Read-only surface**`, the `**Impact**` table, `**Constraints**`. Preserve the block structure verbatim.
+3. **Do NOT pass `**Core decision**` or `**Change Map**`** — those fields reflect the root agent's mental model of the solution. Passing them to `integrity-checker` contaminates its external lens and causes it to grade the diff against the author's intent rather than against the stated `**Impact**` table.
+4. Pass the extracted `## Plan Sketch` inline in the agent prompt, labeled clearly, along with the diff range (`<base>...HEAD`). The agent already knows how to gather the diff itself — do not inline the diff body.
 
 Phase 6 Steps 1–3 **supersede** the three-step outline in `hq:workflow` § Quality Review — do not re-execute `hq:workflow § Quality Review` Steps 1 and 2 here. Only the common rules from `hq:workflow` (progress reporting, file output, FB conventions per `hq:workflow § Feedback Loop`) apply.
 

--- a/plugin/v2/docs/workflow.md
+++ b/plugin/v2/docs/workflow.md
@@ -58,9 +58,11 @@ Phase 1: Load hq:task
 │
 Phase 2: Brainstorm (interactive — user intervention)
 │  Review task, investigate code, align scope
-│  Enumerate Impact on existing features (3 sub-dimensions:
-│    Signature changes / Functional contradictions / Downstream dependencies)
-│  Identify [auto] vs [manual] Acceptance opportunities
+│  Enumerate Editable / Read-only surface (symmetric declaration)
+│  Fill the Impact table (Direction ∈ {Add, Update, Delete, Contradict, Downstream})
+│  Identify the single [auto] [primary] Acceptance signal
+│  Identify further [auto] vs [manual] Acceptance opportunities
+│  Sketch ## Plan grain (ideal 1-5, upper bound 10)
 │  (wait for user "go")
 │
 Phase 3: Plan Generation (autonomous)
@@ -78,8 +80,9 @@ Phase 5: Report
 **Key decisions**:
 
 - No branch, no code, no cache writes in this command. The only artifact is the `hq:plan` Issue.
-- Plan agent must produce the exact `## Plan` + `## Acceptance` structure, with `[auto]` / `[manual]` markers on every Acceptance item.
-- Phase 2 enforces `Impact on existing features` enumeration in the Recap — each Impact entry is contractually tied to a `## Plan` / `## Acceptance` item so downstream drift is caught at drafting time, not deferred to Phase 6 quality review.
+- Plan agent must produce the exact `## Plan Sketch` + `## Plan` + `## Acceptance` structure, with exactly one `[auto] [primary]` item in `## Acceptance`.
+- Phase 2 enforces `Editable surface` / `Read-only surface` symmetric declaration and the `**Impact**` table (`Direction` column uses a closed set of 5 values). Each populated Impact row is contractually tied to a `## Plan` / `## Acceptance` item so downstream drift is caught at drafting time, not deferred to Phase 6 quality review.
+- `## Plan` granularity: ideal 1-5 items, upper bound 10 — each item is a single meaningful commit unit. 10+ items is a drafting defect, not a ceiling.
 - The handoff is intentional — user reviews / edits the `hq:plan` Issue before `/hq:start` is invoked.
 
 ### `/hq:start`
@@ -133,8 +136,9 @@ Phase 6: Quality Review (diff-kind aware)
 │    │  code-reviewer  ║  integrity-checker   │
 │    └────────┬────────╨──────────┬───────────┘
 │             ▼                   ▼
-│  integrity-checker prompt carries plan ## Context (Problem / In scope /
-│  Impact / Out of scope / Constraints) — NOT ## Approach
+│  integrity-checker prompt carries plan ## Plan Sketch (Problem / Editable
+│  surface / Read-only surface / Impact table / Constraints) —
+│  NOT Core decision, NOT Change Map
 │  Fix clearly-actionable FBs (per-FB, retry cap capped by § Settings;
 │  re-run the originating agent only, no cross-agent regression check)
 │  (working tree must be clean at end)
@@ -160,7 +164,7 @@ Phase 8: Report
 - **Commit as you go** — each Plan item and fix lands as its own commit. Working tree is clean by Phase 7.
 - **Acceptance → Quality Review** — Phase 5 confirms the implementation works first (sweep only, looping back to Phase 4 to fix), Phase 6 then reviews quality on a known-working baseline. Reviewing quality before Acceptance would waste effort on code that may not work.
 - **Diff-kind aware Phase 6** — Phase 6 classifies the diff into `code` / `doc` / `mixed`. `security-scanner` skips on `doc`-only diffs (credential / injection patterns structurally cannot appear there). `code-reviewer` and `integrity-checker` always run.
-- **Three-agent Phase 6 with non-overlapping scopes** — `code-reviewer` covers quality / correctness / `/simplify`-era signals with a load-bearing guard against redundant-looking concurrency / lifecycle / subscription / cache / SSR / module-level-mutable-state code. `security-scanner` enumerates alert patterns (runs on `sonnet`). `integrity-checker` reconciles the plan's `## Context` / `**Impact**` against the diff — its invocation prompt carries the full `## Context` block but NOT `## Approach`, to keep its external lens uncontaminated by the author's solution framing.
+- **Three-agent Phase 6 with non-overlapping scopes** — `code-reviewer` covers quality / correctness / `/simplify`-era signals with a load-bearing guard against redundant-looking concurrency / lifecycle / subscription / cache / SSR / module-level-mutable-state code. `security-scanner` enumerates alert patterns (runs on `sonnet`). `integrity-checker` reconciles the plan's `## Plan Sketch` / `**Impact**` table against the diff — its invocation prompt carries the full `## Plan Sketch` block (minus `**Core decision**` and `**Change Map**`), to keep its external lens uncontaminated by the author's solution framing.
 - **Phase 4 ↔ Phase 5 mini-loop** — Phase 5 is a pure sweep; fixes live in Phase 4 (loopback entry). Capped by § Settings FB retry cap per item. This batch-fix model surfaces shared root causes across multiple failing items.
 - **Phase 5 1-by-1 toggle** — per failing `[auto]` item, write the FB (with `covers_acceptance` pointing back to the item) and toggle the checkbox in a single `plan-check-item.sh` tool call. Batch toggles are prohibited.
 - **Phase 6 per-FB independence** — each FB has its own retry budget, and only the originating agent is re-run to verify a fix. Cross-agent regression is accepted as a trade-off for token cost; PR review / `/hq:triage` are the safety net.
@@ -279,27 +283,52 @@ Phase 5: Report
 
 ### Plan Structure
 
-Minimal structural skeleton — every `hq:plan` Issue body MUST include at least the sections below:
+Every `hq:plan` Issue body follows a 3-section structure:
 
 ```markdown
 Parent: #<hq:task issue number>
 
+## Plan Sketch
+
+**Problem** — <pain / why now>
+
+**Editable surface**
+- <file / symbol that this plan MAY modify>
+
+**Read-only surface**
+- <file / symbol that this plan MUST NOT modify>
+
+**Impact**
+
+| Direction | Surface | Kind | Note |
+|---|---|---|---|
+| Add | <new surface> | <kind> | <note> |
+| Update | <changed surface> | <kind> | <what changes> |
+| Delete | <removed surface> | <kind> | <note> |
+| Contradict | <semantically-shifted surface> | <kind> | <how callers may break> |
+| Downstream | <consumer> | <file / section> | <note> |
+
+**Core decision** — <key architectural choice>
+
 ## Plan
-- [ ] <implementation step>
-- [ ] ...
+- [ ] <implementation step — single meaningful commit unit>
 
 ## Acceptance
-- [ ] [auto] <self-verifiable check>
-- [ ] [auto] <another>
+- [ ] [auto] [primary] <single concrete pass/fail signal>
+- [ ] [auto] <secondary verifiable check>
 - [ ] [manual] <requires user verification>
 ```
 
-> **Note**: this is the execution-driving skeleton. In addition, `## Context` is required whenever populated (always in standalone mode) and MUST include `**Problem**`, `**In scope**`, and `**Impact**` (with at least one of the 3 sub-dimensions `Signature changes` / `Functional contradictions` / `Downstream dependencies`). `## Approach` is optional. See `hq:workflow § hq:plan` for the full schema.
+Highlights:
 
-- `## Plan` — implementation steps. All must be checked before PR creation.
-- `## Acceptance` — completion criteria tagged by execution mode:
-  - `[auto]` — Claude executes and toggles (unit tests, API calls, file checks). Prefer `[auto]`.
+- **`## Plan Sketch`** — one scannable section replacing the old `Context` + `Approach` split. `**Editable surface**` / `**Read-only surface**` are both required and symmetric. The `**Impact**` table's `Direction` column is a closed set of 5 values (`Add` / `Update` / `Delete` / `Contradict` / `Downstream`); rows are omitted for directions that do not apply. `**Change Map**` (Mermaid / ASCII figure) and `**Constraints**` are optional — omit entirely when empty.
+- **`## Plan`** — implementation steps. **Ideal 1-5 items, upper bound 10.** Each item is a single meaningful commit unit; adjacent edits to the same file collapse into one item. All must be checked before PR creation.
+- **`## Acceptance`** — completion criteria tagged by execution mode and role:
+  - `[auto]` — Claude executes and toggles (unit tests, API calls, file checks, Playwright). Prefer `[auto]`.
   - `[manual]` — flows to PR body for user verification.
+  - `[primary]` — role marker; combines with `[auto]` only. Exactly one `[auto] [primary]` per plan, designating the single pass/fail signal that tells the plan succeeded. All other `[auto]` items are secondary.
+
+See `hq:workflow § hq:plan` for the authoritative schema, anti-filler policy, and the `[primary]` / granularity rules.
 
 ### Naming Conventions (Conventional Commits)
 

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -63,7 +63,7 @@ Titles follow **Conventional Commits** style. Recognized `<type>` values: `feat`
 Runtime-generated content — `hq:task` / `hq:plan` / PR bodies — is authored in the **conversation language** (the language the user is speaking in this session). Workflow markers and prescribed structural headings stay in **English** regardless, so downstream tooling can parse them.
 
 - **English (fixed)**:
-  - Workflow markers: `Parent: #N`, `[auto]`, `[manual]`, `Closes #<plan>`, `Refs #<task>`
+  - Workflow markers: `Parent: #N`, `[auto]`, `[manual]`, `[primary]`, `Closes #<plan>`, `Refs #<task>`
   - Prescribed headings: `## Plan Sketch`, `## Plan`, `## Acceptance`, `## Manual Verification`, `## Known Issues`, `## Summary`, `## Changes`, `## Notes`
   - File paths, identifiers, code fences, shell commands
 - **Conversation language (content)**:

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -64,11 +64,11 @@ Runtime-generated content — `hq:task` / `hq:plan` / PR bodies — is authored 
 
 - **English (fixed)**:
   - Workflow markers: `Parent: #N`, `[auto]`, `[manual]`, `Closes #<plan>`, `Refs #<task>`
-  - Prescribed headings: `## Plan`, `## Acceptance`, `## Context`, `## Approach`, `## Manual Verification`, `## Known Issues`, `## Summary`, `## Changes`, `## Notes`
+  - Prescribed headings: `## Plan Sketch`, `## Plan`, `## Acceptance`, `## Manual Verification`, `## Known Issues`, `## Summary`, `## Changes`, `## Notes`
   - File paths, identifiers, code fences, shell commands
 - **Conversation language (content)**:
   - `hq:task` body (background / requirements / scope / success criteria)
-  - `hq:plan` body content — `## Context` / `## Approach` prose, each `## Plan` step description, each `## Acceptance` condition
+  - `hq:plan` body content — `## Plan Sketch` prose (Problem / Editable surface / Read-only surface / Impact table cells / Core decision / Constraints), each `## Plan` step description, each `## Acceptance` condition
   - PR body prose — text inside `## Summary` / `## Changes` / `## Notes` and free-form narrative under `## Known Issues`
   - Any free-form section headings the author introduces (e.g., `### 背景`, `### Requirements`)
 
@@ -86,14 +86,14 @@ Parented mode:
                 └── (or escalated during PR review via /hq:triage)
 
 Standalone mode (no parent hq:task):
-  hq:plan Issue  — implementation plan ("how"); top-level, requirement captured in ## Context / **Problem**
+  hq:plan Issue  — implementation plan ("how"); top-level, requirement captured in ## Plan Sketch / **Problem**
     ├── ← Closes → PR  (no Refs trailer)
     │     └── ← /hq:triage → hq:feedback Issue(s)  (residual, Refs #plan)
     └── (or escalated during PR review via /hq:triage)
 ```
 
 - `hq:task` and `hq:plan` are separate issues (separation of concerns)
-- **`hq:task` is optional** — an `hq:plan` can be created without a parent `hq:task` via `/hq:draft` **standalone mode**. Use this when the requirement already lives in an external tracker, or for 1:1 cases where a separate requirement Issue is pure overhead. In standalone mode, the plan's `## Context` / `**Problem**` becomes the sole source of truth for the requirement.
+- **`hq:task` is optional** — an `hq:plan` can be created without a parent `hq:task` via `/hq:draft` **standalone mode**. Use this when the requirement already lives in an external tracker, or for 1:1 cases where a separate requirement Issue is pure overhead. In standalone mode, the plan's `## Plan Sketch` / `**Problem**` becomes the sole source of truth for the requirement.
 - `hq:plan` is created as a **sub-issue** of its parent `hq:task` (GitHub sub-issues API) — **parented mode only**. Standalone-mode plans are top-level Issues with no parent.
 - PR uses `Closes #<hq:plan>` to auto-close the plan issue on merge
 - PR uses `Refs #<hq:task>` to maintain a link to the requirement — **parented mode only**; omitted when the plan has no parent `hq:task`
@@ -110,119 +110,109 @@ Standalone mode (no parent hq:task):
 
 An `hq:plan` issue is the implementation plan that drives work on a branch. The issue body IS the source of truth for what needs to be done and how completion is verified.
 
-The `hq:plan` issue body **must** follow this structure. Substitution / stripping rules for emission:
+The `hq:plan` body follows a 3-section structure: `## Plan Sketch` + `## Plan` + `## Acceptance`. Emission rules:
 
 - Angle-bracket `<placeholder>` tokens are substituted with real content.
-- `<!-- ... -->` HTML comments inside the fence are **meta-annotations** (conditional-emission hints) and MUST be **stripped from the emitted plan body** — they are read by the agent, not written to GitHub.
-- All other fence content is emitted literally.
-
-Conditional emission rules are documented both inline (via the `<!-- ... -->` hints) and in the bullet list below the fence — the two are consistent; the bullet list is authoritative.
+- The `Parent:` line is emitted only in **parented mode** (when the plan has a parent `hq:task`); omit it entirely in **standalone mode**.
+- Optional fields with no substantive content are **omitted entirely** — no label, no placeholder line. Never write `_None._` / `Not applicable` / padded prose as filler.
 
 ```markdown
-<!-- Parent: conditional — emit in parented mode only; omit the entire line in standalone mode -->
 Parent: #<hq:task issue number>
 
-<!-- ## Context: REQUIRED in standalone mode (populate Problem, In scope, and Impact with at least one sub-dimension — no _Intentionally omitted_); optional in parented mode (may be collapsed with _Intentionally omitted: <reason>._) -->
-## Context
+## Plan Sketch
 
-**Problem** — <pain / why now>
+**Problem** — <1-3 sentences: pain and why now>
 
-**In scope**
-- <what's touched>
+**Change Map** *(optional — Mermaid or ASCII figure showing before/after shape; include only when a figure clarifies structure more than prose)*
 
-<!-- **Impact**: required whenever ## Context is populated. Each of the 3 sub-dimensions is individually optional — omit any that is genuinely empty (no label, no _None._). If all 3 would be empty, collapse ## Context itself with _Intentionally omitted: <reason>._ rather than emitting an empty Impact block. -->
+**Editable surface**
+- <file / symbol that this plan MAY modify>
+
+**Read-only surface**
+- <file / symbol that this plan MUST NOT modify>
+
 **Impact**
-- **Signature changes**
-  - Additions: <new public surfaces — functions / frontmatter fields / command names / config keys / rule headings / labels>
-  - Updates: <surfaces whose contract changes — arguments / return shape / emission rules / accepted values>
-  - Deletions: <surfaces being removed>
-- **Functional contradictions**
-  - <signature-stable but semantically-shifted cases where existing callers / consumers may break silently>
-- **Downstream dependencies**
-  - <consumers that need coordinated update across surface categories — code dependencies / build & test / runtime config / documentation / distribution artifacts>
 
-**Out of scope** *(optional — include only when scope is ambiguous or at risk of creep)*
-- <explicit exclusions>
+| Direction | Surface | Kind | Note |
+|---|---|---|---|
+| Add | <new surface> | <field / marker / section / command / ...> | <short note> |
+| Update | <changed surface> | <...> | <what changes> |
+| Delete | <removed surface> | <...> | <...> |
+| Contradict | <semantically-shifted surface> | <...> | <how existing callers may break silently> |
+| Downstream | <consumer needing coordinated update> | <file / section> | <...> |
+
+**Core decision** — <1-2 sentences: the key architectural choice>
 
 **Constraints** *(optional)*
-- <hard dependencies / prerequisites / assumptions>
-
-<!-- ## Approach: optional in BOTH modes; may be collapsed with _Intentionally omitted: <reason>._ (standalone mode does not tighten this section) -->
-## Approach
-
-**Core decision** — <key architectural choice>
-
-**<Aspect label>** — <short detail inline>
-or
-**<Aspect label>**
-- <bullet>
-- <bullet>
-
-**Alternatives considered** *(optional)*
-- <rejected option> — <reason>
+- <hard dependency / prerequisite / assumption>
 
 ## Plan
-- [ ] implementation step 1
-- [ ] implementation step 2
-- [ ] implementation step 3
+- [ ] <implementation step — single meaningful commit unit>
 
 ## Acceptance
-- [ ] [auto] <self-verifiable check, e.g., `pnpm test` passes>
-- [ ] [auto] <e.g., `/api/auth/login` returns 200>
-- [ ] [manual] <requires user confirmation, e.g., browser UI check>
+- [ ] [auto] [primary] <the single concrete pass/fail signal that tells the plan succeeded>
+- [ ] [auto] <secondary verifiable check>
+- [ ] [manual] <human-eye check, used sparingly>
 ```
 
-- **`Parent: #<hq:task issue number>`** *(optional)* — include when the plan is derived from a parent `hq:task` Issue. Omit the line entirely in **standalone mode** (no parent `hq:task`). Standalone-mode plans are created directly from session brainstorming, with no external requirement Issue to point at.
-- **Standalone-mode `## Context` reinforcement** — when `Parent:` is omitted, `## Context` is **required** (not optional) and all three of its required subfields — `**Problem**`, `**In scope**`, and `**Impact**` (with at least one populated sub-dimension) — must be present. `_Intentionally omitted: <reason>._` is forbidden for `## Context` in standalone mode, because the Problem statement is the sole source of truth for the requirement (there is no external Issue to fall back on). `**Impact**` becomes transitively required here: the baseline rule ("required whenever `## Context` is populated") combined with the standalone ban on collapsing `## Context` leaves no escape hatch. `## Approach` retains its normal optionality — only `## Context` is tightened.
-- **`## Context`** *(optional in parented mode; required in standalone mode)* — why this plan exists: motivation, scope boundary, constraints. Captures the reasoning behind the plan that would otherwise evaporate from the `/hq:draft` conversation. When present, use these bold-labeled blocks:
-  - `**Problem**` *(required)* — the pain and why now (1-3 sentences)
-  - `**In scope**` *(required)* — bullets of what's touched (files, features, screens)
-  - `**Impact**` *(required whenever `## Context` is populated)* — existing surfaces affected by the planned change, enumerated across 3 sub-dimensions so downstream drift is caught at drafting time rather than leaking into Phase 6. Each sub-dimension is individually optional — omit any that is genuinely empty **entirely**, meaning drop the `- **<sub-dimension>**` heading line itself, not just its body. No `_None._`, no placeholder-only body. If all 3 would be empty, collapse `## Context` itself with `_Intentionally omitted: <reason>._` instead of emitting an empty Impact block.
-    - **Signature changes** — public surfaces that gain / change / lose their contract. Group by direction (`Additions` / `Updates` / `Deletions`). Surfaces include: functions / methods / types, frontmatter fields, command & subcommand names, config keys, rule or section headings, labels, file paths treated as references.
-    - **Functional contradictions** — signature-stable but semantically-shifted cases where existing callers / consumers may break silently. Example: a command gains a new mode upstream consumers do not yet understand; a label's meaning narrows; a config key accepts a new set of values.
-    - **Downstream dependencies** — consumers that need coordinated update alongside the in-scope change. Sweep across **surface categories** rather than a fixed list of files: (1) **code dependencies** — other modules / commands / skills / agents that import or reference the changed surfaces; (2) **build & test** — build scripts, CI config, test fixtures that encode the old contract; (3) **runtime config** — env vars, feature flags, `.hq/` templates, project-level override files; (4) **documentation** — `README.md`, architecture docs, published guides, tutorials; (5) **distribution artifacts** — plugin manifests, package descriptors, release notes. Name the specific files / sections per category.
-  - `**Out of scope**` *(optional)* — bullets of explicit exclusions. Include only when scope is genuinely ambiguous or at real risk of creep; otherwise omit the block entirely
-  - `**Constraints**` *(optional)* — hard dependencies, prerequisites, or assumptions
+### `## Plan Sketch`
 
-  **Backward compatibility** — `hq:plan` issues created before the `**Impact**` subfield was introduced do not carry it. **Every** skill, agent, or command that reads `hq:plan` bodies — including but not limited to `/hq:start`, the `pr` skill, `/hq:triage`, `/hq:archive`, `/hq:respond`, the `e2e-web` skill, and the `code-reviewer` / `integrity-checker` / `review-comment-analyzer` agents that access plans via `context.md` → `gh/plan.md` — MUST treat a missing `**Impact**` block as valid and proceed without it. A missing `**Impact**` block is NEVER an FB-worthy finding — review agents MUST NOT flag its absence. Do not retroactively edit old plans; new plans produced by `/hq:draft` from this point onward populate the field.
-- **`## Approach`** *(optional)* — high-level implementation direction and key design decisions. Complements the concrete `## Plan` steps by explaining the method. When present, use these bold-labeled blocks:
-  - `**Core decision**` — 1-2 sentences on the key architectural choice. Required when `## Approach` is present; if there is no real design decision to highlight, prefer to omit `## Approach` entirely (with `_Intentionally omitted: <reason>._`)
-  - `**<Aspect label>**` *(free-form, as many as needed)* — one block per distinct component or concern (new helper, API change, mapping, etc.). Short content inline after an en-dash; long content uses a bullet sublist
-  - `**Alternatives considered**` *(optional)* — rejected options with a one-line reason each
-- **`## Plan`** — implementation steps (ToDo list). All items must be checked before PR creation. Progress is visible in the GitHub UI.
-- **`## Acceptance`** — verifiable completion criteria. Each item is tagged with an execution marker:
-  - **`[auto]`** — Claude can verify autonomously using available tools. This includes unit / integration test runs, type checks, builds, shell / CLI commands, API calls, file and directory checks, **and browser automation via `/hq:e2e-web` (Playwright)** — navigation, URL assertions, element / text presence, form submit flows, DOM state checks. Executed during `/hq:start` verification phase.
-  - **`[manual]`** — requires human judgment that tools cannot provide. Four conditions qualify: (1) **subjective** — aesthetics, UX feel, "does this look right"; (2) **physical device or assistive tech** — touch gestures on real devices, screen reader flow, real-world accessibility audits; (3) **live production or sensitive credentials** — checks that require prod auth or customer data Claude should not handle; (4) **multi-session / cross-tab scenarios** Playwright cannot reliably orchestrate. Carried into the PR body and verified by the user during PR review.
+`## Plan Sketch` is the single scannable section that captures motivation, scope boundaries, surface-level impact, and the core design decision. All fields below are bold-labeled blocks within this one heading.
 
-**Choosing `[auto]` vs `[manual]`** — default to `[auto]`. A check is `[manual]` only when one of the four conditions above genuinely applies. **"It happens in a browser" alone does NOT justify `[manual]`** — `/hq:e2e-web` drives browser UI deterministically via Playwright. When unsure, mark as `[auto]` and let `/hq:start` Phase 5 (Acceptance) execution surface the gap if the check is not actually automatable.
+- **`**Problem**`** *(required)* — the pain and why now. 1-3 sentences.
+- **`**Change Map**`** *(optional)* — a Mermaid or ASCII figure showing the before/after shape, included only when the structure of the change reads better as a figure than as prose. GitHub renders Mermaid natively in issue bodies. Omit when a figure would be forced.
+- **`**Editable surface**`** *(required)* — files or symbols this plan MAY modify. Declared explicitly so the implementation phase has an unambiguous "may touch" list.
+- **`**Read-only surface**`** *(required)* — files or symbols this plan MUST NOT modify. The symmetric counterpart to `**Editable surface**` — together they close the set of "what's in play" vs "what stays put". Include adjacent surfaces a reader might assume are in scope but are not.
+- **`**Impact**`** *(required whenever any non-trivial surface is touched)* — a 4-column table: `Direction` / `Surface` / `Kind` / `Note`. The `Direction` column uses a closed set of 5 values:
+  - **`Add`** — a new surface is introduced (new function / field / command / config key / section / label / file path).
+  - **`Update`** — an existing surface's contract changes (arguments, return shape, emission rules, accepted values).
+  - **`Delete`** — an existing surface is removed.
+  - **`Contradict`** — the surface's signature is stable but its semantics shift, potentially breaking existing callers silently. These are the highest-risk entries — flag them clearly in the `Note` column.
+  - **`Downstream`** — a consumer of the edited surface needs a coordinated update (docs, tests, other commands / skills / agents, README, templates, distribution artifacts).
+
+  Omit rows for directions that do not apply. If all 5 directions would be empty, the change is trivial and the `**Impact**` block itself can be skipped.
+- **`**Core decision**`** *(required)* — 1-2 sentences on the key architectural choice. If there is no genuine decision to highlight, the plan probably does not need a `## Plan Sketch` at all.
+- **`**Constraints**`** *(optional)* — hard dependencies, prerequisites, or assumptions. Omit when genuinely empty.
+
+### `## Plan`
+
+Implementation steps as a checkbox list. Every item must be `[x]` before PR creation.
+
+**Granularity — ideal 1-5 items, upper bound 10.** Each item is a **single meaningful commit unit** — something that reads as one independent change in `git log` afterward:
+
+- If two consecutive items would edit the same file in the same editing session, they are **one item**, not two.
+- If an item would produce a half-working intermediate state, it is split wrong — merge upward with its neighbor.
+- 1-item plans are valid (atomic change).
+- 6-10 items is acceptable when the change genuinely spans that many independent concerns.
+- Past 10 items is a drafting defect to fix, not a ceiling to plan up to. 10+ items signals the plan is being written as a step-by-step instruction manual rather than a commit-grain list.
+
+### `## Acceptance`
+
+Verifiable completion criteria. Each item carries an execution marker (`[auto]` or `[manual]`) and optionally a role marker (`[primary]`):
+
+- **`[auto]`** — Claude can verify autonomously: unit / integration tests, type checks, builds, shell / CLI commands, API calls, file / directory / content checks, **and browser automation via `/hq:e2e-web` (Playwright)** — navigation, URL assertions, element / text presence, form submit flows, DOM state. Executed during `/hq:start` Acceptance phase.
+- **`[manual]`** — requires human judgment tools cannot provide. Four conditions qualify: (1) **subjective** — aesthetics, UX feel; (2) **physical device or assistive tech** — touch gestures on real devices, screen reader flow; (3) **live production or sensitive credentials**; (4) **multi-session / cross-tab scenarios** Playwright cannot reliably orchestrate. Carried into the PR body and verified by the user during PR review.
+- **`[primary]`** *(role marker, combines with `[auto]` only)* — **exactly one** `## Acceptance` item per plan MUST carry `[primary]` in addition to `[auto]`. It designates the **single pass/fail signal** that tells the plan succeeded — the one check whose outcome the plan is ultimately judged by. All other `[auto]` items are **secondary** (no explicit marker). `[manual] [primary]` is forbidden — primary must be machine-verifiable so Acceptance Execution can evaluate it deterministically.
+
+**Choosing `[auto]` vs `[manual]`** — default to `[auto]`. A check is `[manual]` only when one of the four conditions above genuinely applies. **"It happens in a browser" alone does NOT justify `[manual]`** — `/hq:e2e-web` drives browser UI deterministically.
+
+**Choosing primary** — the `[primary]` item answers: *"if this single check passes, is the plan done?"* It must be concrete and verifiable (commit count, file existence, specific string presence, API return code, URL transition, etc.) — not an abstract phrase like "plan works" or "implementation complete". Generic phrases dissolve the primary/secondary distinction and count as a drafting defect.
 
 Examples:
 
-| Check | Marker | Why |
+| Check | Markers | Why |
 |---|---|---|
+| Final commit count ≤ 10 and each `## Plan` item appears in a commit subject | `[auto] [primary]` | Single machine-checkable signal of plan success |
+| `pnpm test` passes | `[auto]` | Secondary — necessary but not sufficient |
 | Click "Save" → page URL becomes `/issues/{id}` | `[auto]` | Playwright URL assertion |
 | Form submit → DB row exists | `[auto]` | API / DB check |
-| Back button on direct-loaded `/issues/{id}/edit` navigates to `/issues/{id}` | `[auto]` | Playwright navigation |
-| `pnpm test` passes | `[auto]` | Shell command |
 | Back button's icon matches app's visual style | `[manual]` | Subjective / visual |
 | Swipe-back gesture feels responsive on iOS Safari | `[manual]` | Physical device |
 | Two browser tabs each show the correct tenant after login | `[manual]` | Multi-session orchestration |
 
-**Principle — clarity first, not form-filling.** The labeled blocks above are scaffolding to structure thinking and make the plan scannable. They are **not** a form to fill. If a field would contain fabricated or padded content, omit it:
+Each Acceptance item is a single concrete signal — not a vague goal.
 
-- **Optional fields** (`Out of scope`, `Constraints`, `Alternatives considered`) — leave them out entirely. No label, no placeholder.
-- **Required fields** (`Problem`, `In scope`, `Impact`, `Core decision`) that feel genuinely empty — rethink whether the parent section (`## Context` / `## Approach`) applies at all. If not, omit the whole section with `_Intentionally omitted: <reason>._`. If the section genuinely applies but a required field is still empty, the plan likely needs more thought rather than a placeholder. Special case: if `**Impact**`'s three sub-dimensions would all be empty, that is a signal to collapse `## Context` — not to pad Impact with placeholder content.
-
-Never write filler like `_None._` or "Not applicable" as a substitute for thinking.
-
-**Optional section omission** — when `## Context` or `## Approach` is omitted, do NOT silently drop the heading. Keep the heading and write a single italic line stating the reason, e.g.:
-
-```markdown
-## Approach
-_Intentionally omitted: <one-line reason>._
-```
-
-This signals the author considered the section and chose to leave it empty (vs. forgot it). The preferred form is always "heading present + explicit omission"; silently dropping the heading is discouraged.
+### Registration
 
 After creating an `hq:plan` issue **in parented mode**, register it as a sub-issue of the parent `hq:task`:
 
@@ -231,15 +221,16 @@ PLAN_ID=$(gh api /repos/{owner}/{repo}/issues/<plan> --jq '.id')
 gh api --method POST /repos/{owner}/{repo}/issues/<task>/sub_issues --field sub_issue_id="$PLAN_ID"
 ```
 
-In **standalone mode** (no parent `hq:task`), skip sub-issue registration entirely — there is no parent Issue to register under.
+In **standalone mode** (no parent `hq:task`), skip sub-issue registration entirely.
+
+### Self-contained invariant
 
 Every `hq:plan` must:
 
-- Be **self-contained** — it survives session clears (it's on GitHub, not local)
-- Define **Plan** (implementation steps) and **Acceptance** (completion criteria)
-- Follow the **Language** rule above — content in the conversation language, markers and prescribed headings in English
-- Use the **explicit omission** form (`_Intentionally omitted: <reason>._`) when `## Context` or `## Approach` is left empty (parented mode only — in standalone mode, `## Context` must not be omitted)
-- Keep Acceptance checks atomic and verifiable — each `[auto]` item should map to a single concrete signal (pass/fail)
+- Be **self-contained** — it survives session clears (it lives on GitHub, not locally).
+- Define **`## Plan`** (implementation steps) and **`## Acceptance`** (completion criteria, including exactly one `[auto] [primary]` item).
+- Follow the **Language** rule above — content in the conversation language, markers and prescribed headings in English.
+- Keep Acceptance checks atomic and verifiable — each `[auto]` item maps to a single concrete signal (pass/fail).
 
 ### Focus
 
@@ -432,11 +423,9 @@ Each agent has a fixed, non-overlapping scope. The three scopes together cover t
 
 - **code-reviewer** — readability / correctness / performance / security of the diff itself, plus redundancy signals (unused imports, dead code, obvious duplicated helpers, dead branches). Guarded by a load-bearing rule: the agent MUST NOT recommend removing code that touches concurrency primitives, lifecycle boundaries, subscription / observer machinery, cache dedup / memoization, SSR / hydration boundaries, or module-level mutable state. Output: report + FB files.
 - **security-scanner** — enumerates alert patterns (credentials, external comms, dynamic code) against the diff. Runs on `sonnet` — `haiku` silently no-opped on non-trivial diffs in practice. Skipped on `doc` diffs, which structurally cannot introduce this alert class. Output: scan report only; the root agent decides what is actionable. No FB files.
-- **integrity-checker** — reconciles the `hq:plan` `## Context` (especially `**Impact**`) against the diff. Detects two failure modes: **declared-but-missing** (Impact entry with no corresponding diff change) and **diff-but-undeclared** (diff reach not covered by `**Impact**` or `**Out of scope**`). Scope is narrow by design — it does NOT do general downstream-reference sweeps and does NOT evaluate `## Approach`. **Always launched** — its whole purpose is to catch plan / diff misalignment, which is equally relevant on doc and code diffs. Output: report + FB files.
+- **integrity-checker** — reconciles the `hq:plan` `## Plan Sketch` (especially the `**Impact**` table) against the diff. Detects two failure modes: **declared-but-missing** (Impact row with no corresponding diff change) and **diff-but-undeclared** (diff reach not covered by `**Impact**` or `**Read-only surface**`). Scope is narrow by design — it does NOT do general downstream-reference sweeps and does NOT evaluate the author's `**Core decision**` rationale. **Always launched** — its whole purpose is to catch plan / diff misalignment, which is equally relevant on doc and code diffs. Output: report + FB files.
 
-The caller's invocation prompt MUST pass `integrity-checker` the full `## Context` block of the `hq:plan` (Problem / In scope / Impact / Out of scope / Constraints) and MUST NOT pass `## Approach`. `## Approach` reflects the author's mental model of the solution; passing it would contaminate the agent's external lens.
-
-**Backward compatibility** — when an `hq:plan` has no `**Impact**` block (pre-Impact plans), `integrity-checker` skips the Impact-reconciliation step and exits cleanly with zero FB files. A missing `**Impact**` block is NEVER an FB-worthy finding.
+The caller's invocation prompt MUST pass `integrity-checker` the full `## Plan Sketch` block (Problem / Editable surface / Read-only surface / Impact table / Constraints) and MUST NOT pass `**Core decision**` or `**Change Map**`. Those fields reflect the author's mental model of the solution; passing them would contaminate the agent's external lens.
 
 Wait for all launched agents to complete before proceeding.
 
@@ -452,7 +441,7 @@ If you need fine-grained control or mid-scan user interaction, use the skills di
 
 1. `/security-scan` — pauses on credential detection for user confirmation
 2. `/code-review` — warns about uncommitted changes
-3. `/integrity-check` — reports plan `## Context` / diff reconciliation gaps
+3. `/integrity-check` — reports plan `## Plan Sketch` / diff reconciliation gaps
 
 If any step produces unresolved issues, do not skip ahead. Fix or get user confirmation before continuing.
 

--- a/plugin/v2/skills/integrity-check/SKILL.md
+++ b/plugin/v2/skills/integrity-check/SKILL.md
@@ -2,7 +2,7 @@
 name: integrity-check
 description: >
   Detect end-to-end integrity gaps created by a diff — downstream references that were
-  not updated, half-shipped features, and hidden violations of the plan's `## Out of scope`.
+  not updated, half-shipped features, and hidden violations of the plan's `**Read-only surface**`.
   Explicitly looks **beyond** the hunks: extracts changed symbols / file paths / command /
   rule names from the diff and greps the whole repo for stale references.
 ---
@@ -15,9 +15,9 @@ If `.hq/integrity-check.md` exists, its instructions take precedence over the de
 
 ## Why This Skill Exists
 
-`code-review` looks at the hunks. `security-scan` looks at the hunks. Nothing looks at the files the hunks depend on. When a diff renames a helper, removes a command flag, or changes a rule name, downstream references that were **not touched** by the diff stay stale, and the feature ships half-wired. Plans try to guard this via `## Out of scope`, but scope carve-outs are frequently where the gaps hide: the plan says "X is out of scope," the change depends on X, X is not updated, and no reviewer objects because reviewers honor scope too strictly.
+`code-review` looks at the hunks. `security-scan` looks at the hunks. Nothing looks at the files the hunks depend on. When a diff renames a helper, removes a command flag, or changes a rule name, downstream references that were **not touched** by the diff stay stale, and the feature ships half-wired. Plans try to guard this via `**Read-only surface**`, but scope carve-outs are frequently where the gaps hide: the plan says "X is read-only," the change depends on X, X is not updated, and no reviewer objects because reviewers honor scope too strictly.
 
-This skill's job is to break that blind spot. It reads the diff, pulls every referenceable token out of the changed side, and greps the repo to verify downstream consumers are consistent. Violations are reported as FBs even when they fall outside the plan's `## In scope`.
+This skill's job is to break that blind spot. It reads the diff, pulls every referenceable token out of the changed side, and greps the repo to verify downstream consumers are consistent. Violations are reported as FBs even when they fall outside the plan's `**Editable surface**`.
 
 ## Diff Scope
 
@@ -40,22 +40,22 @@ From the diff, extract every item that can be referenced from elsewhere. For eac
 - **Symbols** — function / method / type / constant / enum-variant names introduced, removed, or renamed. Include language-level identifiers from added/removed declarations on both sides of the hunk.
 - **File paths** — paths that were created, deleted, moved, or renamed. Include both the old and the new path for renames.
 - **Command / subcommand names** — new or removed slash-commands (`/hq:<name>`), CLI subcommands, npm/bun scripts, mise tasks, make targets.
-- **Rule / section names** — structural heading names (`## Out of scope`, `## Known Issues`, `## Context`, `## Acceptance`, …), FB field names, workflow-rule section names (`hq:workflow § <section>`), label names (`hq:plan`, `hq:pr`, …).
+- **Rule / section names** — structural heading names (`## Plan Sketch`, `## Plan`, `## Acceptance`, `## Known Issues`, …), bold-labeled field names (`**Editable surface**`, `**Read-only surface**`, `**Impact**`, `**Core decision**`, …), Impact `Direction` column values (`Add` / `Update` / `Delete` / `Contradict` / `Downstream`), FB field names, workflow-rule section names (`hq:workflow § <section>`), label names (`hq:plan`, `hq:pr`, …).
 - **Config keys** — JSON/YAML/TOML keys added or removed (e.g., `base_branch`, `allowed-tools`), environment variable names.
 - **Public API shape** — exported symbols whose signature (arguments, return type, frontmatter schema) changed. The token did not move, but its contract did — callers may silently break.
 
 ## Review Criteria
 
-The baseline criteria below capture the skill's historical three-class model. The `integrity-checker` agent overrides these at runtime with a narrower scope: reconciliation of the `hq:plan` `## Context` (especially `**Impact**`) against the diff (declared-but-missing / diff-but-undeclared). When invoked interactively via `/integrity-check` without an active plan context, fall back to the three-class model below.
+The baseline criteria below capture the skill's historical three-class model. The `integrity-checker` agent overrides these at runtime with a narrower scope: reconciliation of the `hq:plan` `## Plan Sketch` (especially the `**Impact**` table) against the diff (declared-but-missing / diff-but-undeclared). When invoked interactively via `/integrity-check` without an active plan context, fall back to the three-class model below.
 
 ### 1. Plan / diff reconciliation (primary — agent override)
 
-When a plan's `## Context` with `**Impact**` is available, evaluate these two failure modes:
+When a plan's `## Plan Sketch` with an `**Impact**` table is available, evaluate these two failure modes:
 
-- **Declared-but-missing** — an Impact entry lists a surface / consumer / contradiction, but the diff shows no corresponding change. Either the diff is incomplete or the Impact was aspirational.
-- **Diff-but-undeclared** — the diff reaches a surface or consumer that Impact does not list, and no `## Out of scope` carve-out excuses it. Scope creep hiding in the implementation.
+- **Declared-but-missing** — an `**Impact**` table row lists a surface / consumer / contradiction (`Direction` ∈ {`Add`, `Update`, `Delete`, `Contradict`, `Downstream`}), but the diff shows no corresponding change. Either the diff is incomplete or the Impact row was aspirational.
+- **Diff-but-undeclared** — the diff reaches a surface or consumer that the `**Impact**` table does not list, and no `**Read-only surface**` carve-out excuses it. Scope creep hiding in the implementation.
 
-Backward compat: if the plan has no `**Impact**` block (pre-Impact plans), skip this criterion entirely and exit cleanly without FBs.
+If the `**Impact**` table is absent from the `## Plan Sketch`, emit a single "missing Impact" FB (drafting defect) rather than silently skipping — reconciliation cannot proceed without declared reach.
 
 ### 2. Downstream reference integrity (fallback)
 
@@ -86,7 +86,7 @@ If a feature cannot reach from its declared entrypoint to its declared effect us
 ## Fix Policy
 
 - **Do not modify code directly** — all issues are reported via FB files; the root agent decides what to fix
-- **Scope carve-outs are not a defense** — if the plan's `## Out of scope` is the reason a gap exists, report the gap and call out the scope violation explicitly
+- **Scope carve-outs are not a defense** — if the plan's `**Read-only surface**` is the reason a gap exists, report the gap and call out the scope violation explicitly
 - **Prefer under-reporting false positives over suppressing real gaps** — if integrity cannot be verified (grep is inconclusive), escalate to an FB with the evidence gathered
 
 ## Reporting Format
@@ -100,10 +100,10 @@ Each item must include:
 - **Description** — what is inconsistent, in one or two sentences
 - **Impact** — what breaks, or what misleads, because of this
 - **Severity** — Critical / High / Medium / Low
-- **Scope note** — if the gap falls inside a `## Out of scope` area of the plan, say so and recommend adjusting scope or completing the feature
+- **Scope note** — if the gap falls inside a `**Read-only surface**` area of the plan, say so and recommend adjusting scope or completing the feature
 
 End with a summary:
 
 - Total issues by severity
-- Count of `## Out of scope` violations (subset of the above)
+- Count of `**Read-only surface**` boundary violations (subset of the above)
 - Informational items (no action needed)


### PR DESCRIPTION
## Summary
PR #28 で露呈した `## Plan` 23 項目 × 30 commit 膨張の根因（format の非対称性、primary 非明示、粒度ガードの不在）を解消するため、`hq:plan` フォーマットを `## Plan Sketch` + `## Plan` + `## Acceptance` の 3 節構造に刷新した。Editable/Read-only surface の symmetric 宣言、Impact の 4 列 table 化、`[auto] [primary]` role marker による単一成功指標の明示、`## Plan` 粒度ガイダンス（理想 1-5 / 上限 10 / commit 単位）を format レベルで構造化。後方互換なし（open hq:plan 0 件確認済み）。Karpathy Loop 哲学（agent の自由度を物理的に閉じる）に寄せた spec-as-constraint による gaming 耐性付与が目的。

**Scope amendment (post-review)**: 当初 Read-only surface に宣言していた `plugin/v2/skills/integrity-check/SKILL.md` を FB005 対応として Editable に昇格させ、新 format 前提に更新する commit を追加。plan #30 本文も amendment 済み (`## Plan Sketch` / `## Plan` / `## Acceptance` すべて整合)。

## Changes
- `plugin/v2/skills/bootstrap/templates/workflow.md` § `hq:plan` を新 3 節 template に全面刷新（Plan Sketch / Impact table / `[primary]` marker / granularity rule）、backward-compat clause と `_Intentionally omitted_` 省略形式を削除、Language section の Workflow markers に `[primary]` を追加
- `plugin/v2/agents/integrity-checker.md` の Impact parser を table 行走査 + `Direction` 列分岐ロジックに書換、backward-compat skip を削除して missing Impact は FB 化、Return Message の stale `## Out of scope` metric を `diff-but-undeclared` に更新、bold-in-bold nesting を解消
- `plugin/v2/commands/start.md` Phase 5 After-the-sweep に `[primary]` fail 時の conspicuous report 文言を追加、Phase 6 `integrity-checker` invocation prompt から backward-compat clause (step 5) を削除、bold-in-bold nesting を解消
- `plugin/v2/commands/draft.md` Phase 2 Brainstorm Recap template と Phase 3 Plan agent directive を新 format に刷新（3 sub-dimension 列挙を table 方式に置換、Editable/Read-only enumeration / Primary identification / Plan grain sketch ステップを Phase 2 に追加、primary rule と granularity rule を Phase 3 directive に追加）、stale `workflow.local.md` cross-reference を inline 定義に一本化
- `plugin/v2/docs/workflow.md` § `/hq:draft` overview と § Plan Structure skeleton に Plan Sketch / Editable-Read-only surface / `[primary]` / granularity 上限 概念を反映
- `plugin/v2/skills/integrity-check/SKILL.md` (scope amendment) § Why This Skill Exists / § Extraction Targets / § Review Criteria / § Fix Policy / § Reporting Format の全節を新 format 前提に更新、`## Context` / `## Out of scope` / pre-Impact backward-compat skip の参照を削除

Commit 内訳: 6 plan-item commits + 4 fix commits = 10 commits (primary cap ≤ 10 ギリギリ pass)。Phase 6 Quality Review で code-reviewer / integrity-checker が検出した FB001-FB004 を fix commit で解消、FB005 は scope amendment として plan 本体に取り込み item 6 化。

## Manual Verification
- [ ] [manual] `/hq:draft` を試行（dry-run または新規 topic で）して Phase 2 Recap が新 template shape で自然に出力され、Editable/Read-only surface 欄が無理なく埋まることを目視確認

## Known Issues
`.claude/rules/workflow.local.md` が template 更新に追従していない状態だが、これは CLAUDE.md § Dogfooding で明文化された rebuild artifact (commit ごと同期不要) のため PR scope 外。post-merge で `/hq:bootstrap` を再実行して refresh する想定。

Closes #30
Refs #29