### PR TITLE
refactor: workflow.md から /hq:start 固有 3 セクションを start.md に移植して 40k chars 警告を解消

### DIFF
--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -318,8 +318,6 @@ Launch the agents selected for `DIFF_KIND` by the **Agent launch matrix** in `##
 3. Do NOT pass `**Core decision**` or `**Change Map**` — those fields reflect the root agent's mental model of the solution. Passing them to `integrity-checker` contaminates its external lens and causes it to grade the diff against the author's intent rather than against the stated `**Impact**` table.
 4. Pass the extracted `## Plan Sketch` inline in the agent prompt, labeled clearly, along with the diff range (`<base>...HEAD`). The agent already knows how to gather the diff itself — do not inline the diff body.
 
-Phase 6 Steps 1–3 **supersede** the three-step outline in `hq:workflow` § Quality Review — do not re-execute `hq:workflow § Quality Review` Steps 1 and 2 here. Only the common rules from `hq:workflow` (progress reporting, file output, FB conventions per `hq:workflow § Feedback Loop`) apply.
-
 ### Step 3: Process FBs
 
 Collect pending FBs produced by `code-reviewer` and `integrity-checker` (these are the only Phase 6 agents that write FB files). `security-scanner` findings live in its scan report only — the root agent reads the report, decides what is actionable, and either applies a fix inline (same per-FB rules below, but the "re-run" step consults the scan report rather than re-running the agent) or leaves the residual for human judgment at PR review.

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -192,9 +192,9 @@ Phase 5 is a **sweep only** — it verifies; it does not fix. Fixing happens in 
 
 ### Sweep
 
-Run the **Acceptance Execution** defined in `hq:workflow` § Acceptance Execution:
+For each unchecked `[auto]` item in the plan's `## Acceptance`:
 
-1. For each unchecked `[auto]` item in the plan's `## Acceptance`, execute the check. Browser-oriented checks run via `/hq:e2e-web`.
+1. Execute the check. Browser-oriented checks run via `/hq:e2e-web`.
 2. **On pass**: toggle the cache checkbox via `plan-check-item.sh` (1 tool call = 1 item — see 1-by-1 toggle rule below).
 3. **On fail**: leave the checkbox as `[ ]` and record the failure summary in conversation context (no FB yet).
 4. Track a **sweep counter per item** — how many times this item has cycled through the Phase 4 → Phase 5 loop.
@@ -212,7 +212,7 @@ The sequence per `[auto]` item:
 3. **Toggle** — call `plan-check-item.sh "<unique substring of the item>"` as a **single** tool call. Do not chain multiple items in one call.
 4. Proceed to the next item.
 
-This 1-item = 1-FB = 1-toggle ordering makes the reviewer audit trail linear and keeps the integrity hook quiet. See `hq:workflow` § Acceptance Execution for the shared rule.
+This 1-item = 1-FB = 1-toggle ordering makes the reviewer audit trail linear and keeps the integrity hook quiet.
 
 ### After the sweep
 

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -50,6 +50,21 @@ Tunables for `/hq:start`. Change the value here and every referencing phase foll
   - **Phase 6 (Quality Review)**: maximum times a single clearly-actionable FB may be retried (fix + re-run the **originating agent only** — no cross-agent regression check) before being left pending and escalated to the PR's `## Known Issues`. Per FB independently.
   - Values: `0` skips retries entirely (NG goes straight to FB); `1` permits one retry; `2` is the current default.
 
+## Commit Policy
+
+`/hq:start` commits as work progresses, not at the end. Commits are the unit of work — they make `/hq:start` resume-safe, keep the PR reviewable, and ensure the working tree is clean by the time the PR is created.
+
+Commit granularity by phase:
+
+- **Phase 4 (Execute)** — **one commit per `## Plan` item**. After implementing a step and checking its cache checkbox, create a commit whose subject matches the Plan item. Use Conventional Commits types (`feat`/`fix`/`refactor`/`docs`/`chore`/`test`).
+- **Phase 5 (Acceptance)** — if an `[auto]` check fails and is fixed, create a `fix: <what was wrong>` commit per fix. No commit for pure test runs.
+- **Phase 6 (Quality Review)** — one commit per resolved FB. Subject derived from the FB title (e.g., `fix: <FB subject>`).
+- **Phase 7 (PR Creation)** — no new commits. The working tree MUST be clean at this point; the `pr` skill will not prompt about uncommitted changes.
+
+All commits must pass `hq:workflow` § Before Commit (format + build). Do not skip hooks.
+
+If you discover mid-phase that an earlier commit needs fixing, prefer a new `fix:` commit over `--amend` to keep history linear and resume-safe.
+
 ## Phase 1: Pre-flight Check (non-interactive)
 
 Parse `$ARGUMENTS` → `<hq:plan number>` (accept `#1234` or `1234`). The plan number is **required**. If missing, ask the user ONCE for the `hq:plan` Issue number to implement, then continue.
@@ -66,7 +81,7 @@ existing_branch=$(bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/find-plan-branch
    - `git checkout <existing_branch>` (let git handle any uncommitted changes in the caller's working tree — if checkout fails, **ABORT** per Stop Policy with git's error verbatim)
    - Run `plan-cache-pull.sh <plan>` to refresh the cache (checkpoint: Pull)
    - If the refreshed body differs from the prior cache, print a short unified-diff summary as an advisory note (do not stop)
-   - **Read `hq:workflow`** (`.claude/rules/workflow.local.md`) — auto-resume skips Phase 3, so load the rule file here to have Commit Policy, Feedback Loop, etc. available
+   - **Read `hq:workflow`** (`.claude/rules/workflow.local.md`) — auto-resume skips Phase 3, so load the rule file here to have Feedback Loop, etc. available
    - Determine which phase to resume from by inspecting the cache (see "Resume Phase Selection" below)
    - Mark skipped progress tracking phases as completed
 
@@ -151,7 +166,7 @@ Iterate through unchecked items in the `## Plan` section of `.hq/tasks/<branch-d
    ```bash
    bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-check-item.sh" "<unique substring of the item>"
    ```
-4. **Commit** the item's changes per `hq:workflow` § Commit Policy (one commit per Plan item, Conventional Commits subject).
+4. **Commit** the item's changes per § Commit Policy (one commit per Plan item, Conventional Commits subject).
 5. If a step is blocked or ambiguous, apply the Stop Policy (continue-report): proceed with a reasonable assumption, write an FB under `.hq/tasks/<branch-dir>/feedbacks/` recording the assumption + open question, toggle the checkbox, commit what was done, and move on. The FB escalates to `## Known Issues` in Phase 7.
 6. If an error occurs, fix it. After 2 failed attempts on the same issue, write an FB describing the failure and what remains, toggle the checkbox, commit the partial work, and continue. The unfinished work surfaces in `## Known Issues` and is resolved post-PR via `/hq:triage`.
 
@@ -317,7 +332,7 @@ For each FB:
 2. **Clearly-actionable FBs — retry loop** — up to the FB retry cap times:
    1. Apply a fix.
    2. Run `format` and `build` (`hq:workflow` § Before Commit).
-   3. Create a `fix: <FB subject>` commit per `hq:workflow` § Commit Policy.
+   3. Create a `fix: <FB subject>` commit per § Commit Policy.
    4. **Re-run the originating agent only** — the single agent that wrote this FB. Do not re-run the full Phase 6 agent set; cross-agent regression is not a Phase 6 concern (see Per-FB independence above).
    5. If the FB is gone from the re-run output, move the FB file to `feedbacks/done/` and exit the loop.
    6. Otherwise, continue the loop up to the cap.
@@ -380,7 +395,7 @@ Summarize:
 - **Autonomous after Phase 1** — once past pre-flight, do not pause for user input. Residuals flow to the PR's `## Known Issues` via FB files, not mid-flight prompts.
 - **Cache-first** — during Phases 4–7, plan body reads/writes target `.hq/tasks/<branch-dir>/gh/plan.md` only. Never call `gh issue edit <plan>` directly. All GitHub pushes go through `plan-cache-push.sh` at the checkpoints defined in `hq:workflow` § Cache-First Principle.
 - **Do not skip Phase 5 or Phase 6** — acceptance and quality review are mandatory.
-- **Commit as you go** — follow `hq:workflow` § Commit Policy. The working tree must be clean by Phase 7.
+- **Commit as you go** — follow § Commit Policy. The working tree must be clean by Phase 7.
 - **FB escalation to PR body is atomic** — listing in the body and moving to `done/` happen together (see `hq:workflow` § Feedback Loop).
 - **No `hq:feedback` creation** — this command does NOT create `hq:feedback` Issues. That happens via `/hq:triage` during PR review.
 

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -337,38 +337,6 @@ The following structural elements of the PR body are invariants of the HQ workfl
 
 A newly bootstrapped repository should understand these rules from this section alone — `.hq/pr.md` overrides are applied on top, never in place of, the invariants above.
 
-## Acceptance Execution
-
-Verifies the `hq:plan` is complete — that the implementation satisfies every `[auto]` item in the `## Acceptance` section. This is the primary completion gate of an `hq:plan`.
-
-Acceptance is a **sweep-only** step for the caller — it verifies; it does not fix in place. Fixing is the caller's implementation phase. For `/hq:start`, this is the Phase 4 ↔ Phase 5 loopback (see its § Phase 4 and § Phase 5). The separation makes root-cause analysis easier: a batch of failures often points to a shared cause that is obvious only when all failures are visible at once.
-
-Sweep steps:
-
-1. For each unchecked `[auto]` item, execute the check autonomously. Kind depends on the item:
-   - Shell command, test run, type check, build
-   - API / file / directory check
-   - Browser automation via `/hq:e2e-web` for navigation, URL assertion, element/text presence, form submit, DOM state
-2. **On pass**: toggle the checkbox via `plan-check-item.sh` (cache only; 1 tool call = 1 item — see 1-by-1 toggle rule below).
-3. **On fail**: leave the checkbox as `[ ]` and record the failure summary for the caller. Do NOT fix in this step.
-
-### 1-by-1 toggle rule (batch toggle prohibited)
-
-Process each `[auto]` item **sequentially**, one tool call per item. Batch toggling multiple checkboxes in a single `plan-check-item.sh` invocation (or in a single compound bash line) is forbidden — it trips the integrity hook, which treats multi-toggle activity without per-item FB evidence as a state-laundering signal.
-
-Per-item sequence:
-
-1. **Classify** — determine the outcome: `pass` / `retry-possible` / `pre-existing` / `deferred` / `deliberate` / `partial-verification`.
-2. **FB (if applicable)** — for any outcome other than `pass`, write or reference an FB file under `.hq/tasks/<branch-dir>/feedbacks/`. Populate the FB frontmatter `covers_acceptance` field with a unique substring of the acceptance item it covers (see `## Feedback Loop`).
-3. **Toggle** — call `plan-check-item.sh "<unique substring of the item>"` as a **single** tool call. Do not chain multiple items in one call.
-4. Proceed to the next item.
-
-After the sweep, the caller decides what to do with failures (loopback to implementation, record FB, escalate, etc.). The caller's retry cap — for `/hq:start`, see its § Settings — governs how many sweep rounds a single item may go through before being demoted to an FB. When that cap is exhausted, the item is converted to an FB and its checkbox is toggled to `[x]` anyway so the final PR gate is not deadlocked by a tracked failure.
-
-`[manual]` items are NOT executed here — they remain unchecked and flow to the PR body's `## Manual Verification` section.
-
-Acceptance must be satisfied (all `[auto]` items `[x]` — either truly passing, or `[x]` with a pending FB) before Quality Review runs. The order is deliberate: confirm the implementation works first, then review quality on a known-working baseline. Reviewing quality before Acceptance wastes effort on code that may not work.
-
 ## Quality Review
 
 Runs after Acceptance is satisfied. Verifies the diff meets the project's quality, security, and plan-alignment bar, independent of whether the plan was met functionally. For `/hq:start` this is Phase 6; other callers may schedule it differently but reuse the same three-agent structure.

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -361,7 +361,7 @@ Skills that perform verification or review may output feedback files (FB) to `.h
 
 - Read pending FB files and assess each: fix only those that are clearly actionable (bugs, typos, logic errors). Leave design-level or scope-ambiguous FBs as-is for user judgment.
 - Run `format` and `build` commands after fixes
-- Re-run the originating agent only to verify the specific FB is gone. Do NOT re-run the full agent set — cross-agent regression is accepted as a trade-off (see `## Quality Review § Step 3`)
+- Re-run the originating agent only to verify the specific FB is gone. Do NOT re-run the full agent set — cross-agent regression is accepted as a trade-off for review token cost
 - When an FB item is **resolved in-branch**, move its file to `feedbacks/done/`
 - When an FB item is **escalated to the PR body's `## Known Issues`** at PR creation time, move its file to `feedbacks/done/` as well — its role has shifted to the PR body (now the source of truth for residual problems)
 - The fix → re-verify cycle runs up to the caller's **FB retry cap**, applied **per FB independently** (FB A's failed retries do not consume FB B's budget). `/hq:start` defines its cap in its `## Settings` section (default `2`); other callers MUST supply their own. When the cap is exhausted on a given FB, escalate that FB to the PR body and move its file to `done/`.

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -337,67 +337,6 @@ The following structural elements of the PR body are invariants of the HQ workfl
 
 A newly bootstrapped repository should understand these rules from this section alone — `.hq/pr.md` overrides are applied on top, never in place of, the invariants above.
 
-## Quality Review
-
-Runs after Acceptance is satisfied. Verifies the diff meets the project's quality, security, and plan-alignment bar, independent of whether the plan was met functionally. For `/hq:start` this is Phase 6; other callers may schedule it differently but reuse the same three-agent structure.
-
-### Step 1: Classify the diff
-
-Quality Review is **diff-kind aware** — the agent set depends on whether the diff is code, doc, or a mix. Single-pass, extension-based, case-insensitive classification of `git diff --name-only <base>...HEAD`:
-
-- **All changed files have a doc extension** → `doc`
-- **No changed file has a doc extension** → `code`
-- **Mix** → `mixed`
-
-Doc extensions (case-insensitive):
-
-| Group | Extensions |
-|---|---|
-| Markdown / structured text | `.md`, `.mdx`, `.markdown`, `.txt`, `.rst`, `.adoc`, `.asciidoc` |
-| Microsoft Office | `.docx`, `.doc`, `.pptx`, `.ppt`, `.xlsx`, `.xls` |
-| OpenDocument | `.odt`, `.odp`, `.ods` |
-| Google Docs (Drive shortcuts) | `.gdoc`, `.gsheet`, `.gslides` |
-| Apple iWork | `.pages`, `.numbers`, `.key` |
-| Portable | `.pdf`, `.rtf` |
-
-Anything not in this table (including `.yaml`, `.json`, `.toml`, `.sh`, and other config / scripting formats) is treated as **code**.
-
-### Step 2: Launch agent set (parallel)
-
-Launch the agent subset selected by `DIFF_KIND` **simultaneously** via the Agent tool. All launched agents run autonomously and return summaries with report / FB file paths.
-
-| Kind | `code-reviewer` | `security-scanner` | `integrity-checker` |
-|---|---|---|---|
-| `code` | ✓ | ✓ | ✓ |
-| `doc` | ✓ | — (skip) | ✓ |
-| `mixed` | ✓ | ✓ | ✓ |
-
-Each agent has a fixed, non-overlapping scope. The three scopes together cover the review surface without duplication:
-
-- **code-reviewer** — readability / correctness / performance / security of the diff itself, plus redundancy signals (unused imports, dead code, obvious duplicated helpers, dead branches). Guarded by a load-bearing rule: the agent MUST NOT recommend removing code that touches concurrency primitives, lifecycle boundaries, subscription / observer machinery, cache dedup / memoization, SSR / hydration boundaries, or module-level mutable state. Output: report + FB files.
-- **security-scanner** — enumerates alert patterns (credentials, external comms, dynamic code) against the diff. Runs on `sonnet` — `haiku` silently no-opped on non-trivial diffs in practice. Skipped on `doc` diffs, which structurally cannot introduce this alert class. Output: scan report only; the root agent decides what is actionable. No FB files.
-- **integrity-checker** — reconciles the `hq:plan` `## Plan Sketch` (especially the `**Impact**` table) against the diff. Detects two failure modes: **declared-but-missing** (Impact row with no corresponding diff change) and **diff-but-undeclared** (diff reach not covered by `**Impact**` or `**Read-only surface**`). Scope is narrow by design — it does NOT do general downstream-reference sweeps and does NOT evaluate the author's `**Core decision**` rationale. **Always launched** — its whole purpose is to catch plan / diff misalignment, which is equally relevant on doc and code diffs. Output: report + FB files.
-
-The caller's invocation prompt MUST pass `integrity-checker` the full `## Plan Sketch` block (Problem / Editable surface / Read-only surface / Impact table / Constraints) and MUST NOT pass `**Core decision**` or `**Change Map**`. Those fields reflect the author's mental model of the solution; passing them would contaminate the agent's external lens.
-
-Wait for all launched agents to complete before proceeding.
-
-### Step 3: Fix FB Issues
-
-Read pending FB files from `code-reviewer` and `integrity-checker` (the two agents that produce FBs). `security-scanner` findings appear only in its scan report — the root agent reads the report and decides what is actionable.
-
-FB handling is **per-FB independent** — each FB has its own retry budget. **Only the originating agent is re-run** to verify a fix; cross-agent regression is accepted as a trade-off for review token cost and caught later by PR review / `/hq:triage`. Follow the FB Handling Rules in `## Feedback Loop`, using the caller's FB retry cap (for `/hq:start`, see its § Settings).
-
-### Fallback: Interactive Mode
-
-If you need fine-grained control or mid-scan user interaction, use the skills directly instead of agents:
-
-1. `/security-scan` — pauses on credential detection for user confirmation
-2. `/code-review` — warns about uncommitted changes
-3. `/integrity-check` — reports plan `## Plan Sketch` / diff reconciliation gaps
-
-If any step produces unresolved issues, do not skip ahead. Fix or get user confirmation before continuing.
-
 ## Feedback Loop
 
 Skills that perform verification or review may output feedback files (FB) to `.hq/tasks/<branch-dir>/feedbacks/`.

--- a/plugin/v2/skills/bootstrap/templates/workflow.md
+++ b/plugin/v2/skills/bootstrap/templates/workflow.md
@@ -17,21 +17,6 @@
 1. Run `format` command (see Commands table in CLAUDE.md)
 2. Verify `build` command passes
 
-## Commit Policy
-
-`/hq:start` commits as work progresses, not at the end. Commits are the unit of work — they make `/hq:start` resume-safe, keep the PR reviewable, and ensure the working tree is clean by the time the PR is created.
-
-Commit granularity by phase:
-
-- **Phase 4 (Execute)** — **one commit per `## Plan` item**. After implementing a step and checking its cache checkbox, create a commit whose subject matches the Plan item. Use Conventional Commits types (`feat`/`fix`/`refactor`/`docs`/`chore`/`test`).
-- **Phase 5 (Acceptance)** — if an `[auto]` check fails and is fixed, create a `fix: <what was wrong>` commit per fix. No commit for pure test runs.
-- **Phase 6 (Quality Review)** — one commit per resolved FB. Subject derived from the FB title (e.g., `fix: <FB subject>`).
-- **Phase 7 (PR Creation)** — no new commits. The working tree MUST be clean at this point; the `pr` skill will not prompt about uncommitted changes.
-
-All commits must pass `## Before Commit` (format + build). Do not skip hooks.
-
-If you discover mid-phase that an earlier commit needs fixing, prefer a new `fix:` commit over `--amend` to keep history linear and resume-safe.
-
 ## Terminology
 
 - **`hq:workflow`** — shorthand for `.claude/rules/workflow.local.md` (the project-local copy of the workflow rule file, produced by `/hq:bootstrap`). Skills and commands cite sections as `hq:workflow § <section>` instead of repeating the full path.


### PR DESCRIPTION
## Summary

`.claude/rules/workflow.local.md` が 41.3k chars に達し、Claude Code の「40k chars 超えでパフォーマンス影響」警告を出していた問題を解消する refactor。SOT `plugin/v2/skills/bootstrap/templates/workflow.md` に `/hq:start` 固有の実装詳細が共通ルール集に混入していたのが原因だったので、3 セクション（Commit Policy / Acceptance Execution / Quality Review）を `plugin/v2/commands/start.md` に物理移動した。

workflow.md は 37,530 bytes → 28,592 bytes（約 24% 減）で、40k chars 警告閾値を安全マージン付きで下回る。「中身は変えず、場所だけ変える」契約のプランで、セマンティクスは維持。skill 化および workflow.md 全体の圧縮は別 plan として切り分けた（plan B / plan A.5）。

## Changes

- `plugin/v2/skills/bootstrap/templates/workflow.md`（SOT）から 3 セクションを削除:
  - `## Commit Policy`（1,158 bytes）
  - `## Acceptance Execution`（3,013 bytes）
  - `## Quality Review`（4,708 bytes）
- `plugin/v2/commands/start.md` に `## Commit Policy` 節を新設（Phase 4-7 に分散していた commit 方針への言及を一元化）
- `plugin/v2/commands/start.md` Phase 5 / Phase 6 の `hq:workflow § Acceptance Execution` / `§ Quality Review` 引用および "supersede" 表現を撤去
- 副次 fix: workflow.md § Feedback Loop の `(see ## Quality Review § Step 3)` dangling 参照を撤去（Quality Review セクション削除に伴う取り残し、quality review agent が検出した FB001 を解消）

## Notes

- `.claude/rules/workflow.local.md` は dogfooding copy（CLAUDE.md § Dogfooding に "Not a development target" / "refreshed out-of-band" と明記）のため本 PR では触っていない。merge 後に `/hq:bootstrap` 再実行で同期される。
- skill 化（plan B）と workflow.md の他セクション圧縮（plan A.5）は別 plan として着手予定。

Closes #32