### PR TITLE
feat: /hq:start Phase 8 Report に phase timing 集計を追加

### DIFF
--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -438,7 +438,12 @@ bash plugin/v2/scripts/phase-timing.sh summary
 
 The summary prints per-phase wall-clock duration (Phase 1–7), a total, and the session count (how many times Phase 1 `start` fired — i.e., how often the run was interrupted and auto-resumed). Note in the Report that the durations are wall-clock and include any idle / interrupted time between matching stamps; they are not a proxy for active work.
 
-Phases that have no recorded stamps appear as `(no data)` — typically Phase 2 / Phase 3 on auto-resume (skipped entirely) or phases that ran on a different branch before Phase 3 created the feature branch. This is an accepted limitation of the wall-clock design.
+Phases that have no recorded stamps appear as `(no data)`. Two scenarios produce this:
+
+- **Fresh start** — Phase 1 and Phase 2 run before the feature branch is created (Phase 3 step 2), so their stamps land in the base branch's `.hq/tasks/<base-branch-dir>/phase-timings.jsonl`. Phase 8 reads the feature branch's file and therefore shows Phase 1 and Phase 2 as `(no data)`.
+- **Auto-resume** — Phase 2 and Phase 3 are skipped entirely (the branch and cache already exist), so they produce no stamps for that session.
+
+This is an accepted limitation of the wall-clock design — the stamped phases (4–7 always, plus 1–3 when they run on the feature branch) cover the bulk of the execution time.
 
 ## Rules
 

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -64,7 +64,22 @@ All commits must pass `hq:workflow` § Before Commit (format + build). Do not sk
 
 If you discover mid-phase that an earlier commit needs fixing, prefer a new `fix:` commit over `--amend` to keep history linear and resume-safe.
 
+## Phase Timing
+
+`/hq:start` records a wall-clock timestamp at every phase boundary so Phase 8 can report where the run spent its time. For each of Phase 1–7, stamp once at the top of the phase and once at the bottom:
+
+```
+bash plugin/v2/scripts/phase-timing.sh stamp <N> start
+bash plugin/v2/scripts/phase-timing.sh stamp <N> end
+```
+
+Each call appends one line — `{"phase":"<N>","event":"<start|end>","ts":<unix_secs>}` — to `.hq/tasks/<branch-dir>/phase-timings.jsonl`. Auto-resume sessions append to the same file; session count is the number of `phase":"1","event":"start"` entries. Phase 8 summarizes the file via `phase-timing.sh summary`. Durations are wall-clock and include any idle or interrupted time between matching stamps — the plan tolerates this; it measures real elapsed time, not active work.
+
+The concrete stamp invocation for each phase is placed at that phase's top and bottom below.
+
 ## Phase 1: Pre-flight Check (non-interactive)
+
+**Stamp start:** `bash plugin/v2/scripts/phase-timing.sh stamp 1 start`
 
 Parse `$ARGUMENTS` → `<hq:plan number>` (accept `#1234` or `1234`). The plan number is **required**. If missing, ask the user ONCE for the `hq:plan` Issue number to implement, then continue.
 
@@ -104,7 +119,11 @@ Read `.hq/tasks/<branch-dir>/gh/plan.md` and inspect checkbox state:
 
 The Phase 4 ↔ Phase 5 loopback has no cache-visible state of its own — the sweep counter lives in conversation context only. On auto-resume after interruption, the sweep counter resets to zero (Phase 5 re-runs from the beginning; already-passed items stay `[x]` and are skipped).
 
+**Stamp end:** `bash plugin/v2/scripts/phase-timing.sh stamp 1 end`
+
 ## Phase 2: Load Plan (fresh start only)
+
+**Stamp start:** `bash plugin/v2/scripts/phase-timing.sh stamp 2 start`
 
 Fetch the `hq:plan` Issue:
 
@@ -130,7 +149,11 @@ Keep the plan payload (and, in parented mode, the task payload) in conversation 
 - Example: `feat(plan): implement user authentication with OAuth 2.0` → `feat/oauth-login`
 - Keep the description short (≤ 40 chars, kebab-case, alphanumeric + hyphens).
 
+**Stamp end:** `bash plugin/v2/scripts/phase-timing.sh stamp 2 end`
+
 ## Phase 3: Execution Prep (fresh start only)
+
+**Stamp start:** `bash plugin/v2/scripts/phase-timing.sh stamp 3 start`
 
 1. **Resolve base branch** per workflow rule: `.hq/settings.json` `base_branch` → `git symbolic-ref refs/remotes/origin/HEAD` → `main`.
 2. **Create feature branch** from base:
@@ -148,7 +171,11 @@ Keep the plan payload (and, in parented mode, the task payload) in conversation 
 6. **Save focus to memory** — a project-type memory entry with branch name, plan number, and — **parented mode only** — source number. In standalone mode, omit the source number from the memory entry (there is no parent `hq:task`).
 7. **Read `hq:workflow`** (`${CLAUDE_PLUGIN_ROOT}/plugin/v2/rules/workflow.md`) and follow all applicable rules.
 
+**Stamp end:** `bash plugin/v2/scripts/phase-timing.sh stamp 3 end`
+
 ## Phase 4: Execute
+
+**Stamp start:** `bash plugin/v2/scripts/phase-timing.sh stamp 4 start`
 
 Phase 4 runs in two modes depending on how it was entered:
 
@@ -185,7 +212,11 @@ Phase 5 has just recorded one or more failing `[auto]` items and handed them bac
 
 Then return to Phase 5 for the next sweep. The retry cap (§ Settings) limits how many times a given `[auto]` item can cycle back here before being recorded as an FB.
 
+**Stamp end:** `bash plugin/v2/scripts/phase-timing.sh stamp 4 end`
+
 ## Phase 5: Acceptance
+
+**Stamp start:** `bash plugin/v2/scripts/phase-timing.sh stamp 5 start`
 
 Phase 5 is a **sweep only** — it verifies; it does not fix. Fixing happens in Phase 4 (loopback entry). Keeping "does the implementation meet the plan?" and "what needs to change to meet it?" in separate phases makes root-cause analysis easier — a batch of failures often points to a shared cause that's obvious only when all of them are visible at once.
 
@@ -237,6 +268,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-cache-push.sh" <plan>   # che
 ```
 
 The `Phase 4 → Phase 5` loopback does NOT push between iterations — pushing happens once Phase 5 finally exits.
+
+**Stamp end:** `bash plugin/v2/scripts/phase-timing.sh stamp 5 end`
 
 ## Diff Classification
 
@@ -298,6 +331,8 @@ The classification drives which agents run in Phase 6 (Quality Review). Each age
 
 ## Phase 6: Quality Review
 
+**Stamp start:** `bash plugin/v2/scripts/phase-timing.sh stamp 6 start`
+
 Phase 6 launches the agent subset selected by `DIFF_KIND` per the **Agent launch matrix** in `## Diff Classification` above.
 
 ### Step 1: Classify the diff
@@ -341,7 +376,11 @@ Resolved FBs are moved to `feedbacks/done/` per `hq:workflow` § Feedback Loop; 
 
 Quality Review is independent of cache state — no checkpoint push here. The working tree must be clean when this phase ends.
 
+**Stamp end:** `bash plugin/v2/scripts/phase-timing.sh stamp 6 end`
+
 ## Phase 7: PR Creation
+
+**Stamp start:** `bash plugin/v2/scripts/phase-timing.sh stamp 7 start`
 
 ### Gate
 
@@ -374,6 +413,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-cache-push.sh" <plan>
 
 Delegate to the `pr` skill with the prepared body, title, and — **parented mode only** — milestone / project inherited from the `hq:task` (read `.hq/tasks/<branch-dir>/gh/task.json`). In standalone mode, skip milestone / project resolution entirely — there is no `task.json` cache file and no parent `hq:task` to inherit from, so no `--milestone` / `--project` flags are passed. The `pr` skill is the single path to `gh pr create` and applies any `.hq/pr.md` overrides within its own documented scope. Do not call `gh pr create` directly.
 
+**Stamp end:** `bash plugin/v2/scripts/phase-timing.sh stamp 7 end`
+
 ## Phase 8: Report
 
 Summarize:
@@ -386,6 +427,18 @@ Summarize:
 - **PR**: URL
 - **Manual verification items**: count (to be done by user in PR review)
 - **Known Issues**: count (handle via `/hq:triage <PR>` after review)
+
+### Timing
+
+Run the phase-timing summary and include its output in the report so the user can see where the run spent its time:
+
+```bash
+bash plugin/v2/scripts/phase-timing.sh summary
+```
+
+The summary prints per-phase wall-clock duration (Phase 1–7), a total, and the session count (how many times Phase 1 `start` fired — i.e., how often the run was interrupted and auto-resumed). Note in the Report that the durations are wall-clock and include any idle / interrupted time between matching stamps; they are not a proxy for active work.
+
+Phases that have no recorded stamps appear as `(no data)` — typically Phase 2 / Phase 3 on auto-resume (skipped entirely) or phases that ran on a different branch before Phase 3 created the feature branch. This is an accepted limitation of the wall-clock design.
 
 ## Rules
 

--- a/plugin/v2/scripts/phase-timing.sh
+++ b/plugin/v2/scripts/phase-timing.sh
@@ -23,14 +23,17 @@ EOF
 }
 
 resolve_jsonl() {
-  local branch_raw
+  local root branch_raw
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "error: not inside a git repository" >&2; exit 1
+  }
   branch_raw=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
   if [[ -z "$branch_raw" || "$branch_raw" == "HEAD" ]]; then
     echo "error: not on a named branch (detached HEAD)" >&2
     exit 1
   fi
   local branch_dir=${branch_raw//\//-}
-  echo ".hq/tasks/${branch_dir}/phase-timings.jsonl"
+  echo "${root}/.hq/tasks/${branch_dir}/phase-timings.jsonl"
 }
 
 [[ $# -ge 1 ]] || usage

--- a/plugin/v2/scripts/phase-timing.sh
+++ b/plugin/v2/scripts/phase-timing.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Phase timing helper for /hq:start.
+# Subcommands:
+#   stamp <phase> <event>   append a timing event to the branch-local JSONL
+#   summary                 print wall-clock duration per phase + total + session count
+#
+# JSONL path: .hq/tasks/<branch-dir>/phase-timings.jsonl
+# Event format: {"phase":"<N>","event":"<start|end>","ts":<unix_secs>}
+#
+# Durations are wall-clock and include any idle / interrupted time between
+# a `start` stamp and its matching `end` stamp across auto-resume sessions.
+# Session count = number of `{"phase":"1","event":"start",...}` events.
+set -euo pipefail
+IFS=$'\n\t'
+
+usage() {
+  cat >&2 <<EOF
+Usage:
+  $(basename "$0") stamp <phase> <event>
+  $(basename "$0") summary
+EOF
+  exit 2
+}
+
+resolve_jsonl() {
+  local branch_raw
+  branch_raw=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [[ -z "$branch_raw" || "$branch_raw" == "HEAD" ]]; then
+    echo "error: not on a named branch (detached HEAD)" >&2
+    exit 1
+  fi
+  local branch_dir=${branch_raw//\//-}
+  echo ".hq/tasks/${branch_dir}/phase-timings.jsonl"
+}
+
+[[ $# -ge 1 ]] || usage
+cmd="$1"
+shift
+
+case "$cmd" in
+  stamp)
+    [[ $# -eq 2 ]] || usage
+    phase="$1"
+    event="$2"
+    [[ "$phase" =~ ^[1-7]$ ]] || { echo "error: <phase> must be 1-7" >&2; exit 2; }
+    [[ "$event" == "start" || "$event" == "end" ]] || { echo "error: <event> must be 'start' or 'end'" >&2; exit 2; }
+    jsonl=$(resolve_jsonl)
+    mkdir -p "$(dirname "$jsonl")"
+    ts=$(date +%s)
+    printf '{"phase":"%s","event":"%s","ts":%s}\n' "$phase" "$event" "$ts" >> "$jsonl"
+    ;;
+  summary)
+    [[ $# -eq 0 ]] || usage
+    jsonl=$(resolve_jsonl)
+    if [[ ! -s "$jsonl" ]]; then
+      echo "No timing data recorded."
+      exit 0
+    fi
+    awk '
+      {
+        ph = $0
+        sub(/.*"phase":"/, "", ph); sub(/".*/, "", ph)
+        ev = $0
+        sub(/.*"event":"/, "", ev); sub(/".*/, "", ev)
+        ts = $0
+        sub(/.*"ts":/, "", ts); sub(/[^0-9].*/, "", ts)
+        ts = ts + 0
+
+        if (ph == "1" && ev == "start") session++
+        phase_seen[ph] = 1
+
+        if (ev == "start") {
+          n_starts[ph]++
+          starts[ph, n_starts[ph]] = ts
+        } else if (ev == "end") {
+          for (i = 1; i <= n_starts[ph]; i++) {
+            if (!used[ph, i]) {
+              used[ph, i] = 1
+              dur = ts - starts[ph, i]
+              if (dur < 0) dur = 0
+              phase_dur[ph] += dur
+              total += dur
+              break
+            }
+          }
+        }
+      }
+      END {
+        for (i = 1; i <= 7; i++) {
+          ph = i ""
+          if (phase_seen[ph]) {
+            printf "Phase %s: %s\n", ph, fmt(phase_dur[ph] + 0)
+          } else {
+            printf "Phase %s: (no data)\n", ph
+          }
+        }
+        print ""
+        printf "Total: %s\n", fmt(total + 0)
+        printf "Sessions: %d\n", session + 0
+      }
+      function fmt(s,   h, m, r) {
+        if (s <= 0) return "0s"
+        h = int(s / 3600)
+        m = int((s % 3600) / 60)
+        r = s % 60
+        if (h > 0) return sprintf("%dh %dm %ds", h, m, r)
+        if (m > 0) return sprintf("%dm %ds", m, r)
+        return sprintf("%ds", r)
+      }
+    ' "$jsonl"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/plugin/v2/scripts/phase-timing.sh
+++ b/plugin/v2/scripts/phase-timing.sh
@@ -61,6 +61,9 @@ case "$cmd" in
     fi
     awk '
       {
+        # Skip lines that are not complete timing records (e.g., truncated writes).
+        if ($0 !~ /"phase":"[1-7]".*"event":"(start|end)".*"ts":[0-9]+/) next
+
         ph = $0
         sub(/.*"phase":"/, "", ph); sub(/".*/, "", ph)
         ev = $0


### PR DESCRIPTION
## Summary
`/hq:start` の Phase 8 Final Report に各 Phase の wall-clock 経過時間を集計する phase timing 機構を追加。どの Phase がボトルネックか、何回 auto-resume したか、が見えるようになる。

## Changes
- `plugin/v2/scripts/phase-timing.sh` 新規追加 — `stamp <phase> <event>` / `summary` サブコマンド。append-only JSONL に書き込み、`summary` は start/end を phase ごとにペアリングして wall-clock duration を集計する。
- `plugin/v2/commands/start.md` — Phase 1〜7 の各境界に stamp 呼び出しを追加（14 箇所）、Phase 8 に `### Timing` 小節を追加、冒頭に Phase Timing contract を明文化。
- パスは `git rev-parse --show-toplevel` で repo root に anchor、awk `summary` は truncated JSONL 行を skip する guard 付き。

## Notes
- Standalone mode（parent `hq:task` なし）
- Timing は wall-clock（中断時間を含む）。これは意図通りで、active work 時間を測るものではない。
- Fresh-start 時の Phase 1/2 は feature branch 作成前に走るため `(no data)` になる — 受容された制約として Phase Timing preamble に明記。
- Phase 6 Quality Review: code-reviewer が 3 FB（HIGH/MEDIUM/LOW）を検出、3 つとも本 PR 内で解消。security-scanner 0 alerts、integrity-checker 0 gaps。

Closes #38