### PR TITLE
feat: workflow § Before Commit に blast-radius self-check を追加

### DIFF
--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -60,7 +60,7 @@ Commit granularity by phase:
 - **Phase 6 (Quality Review)** — one commit per resolved FB. Subject derived from the FB title (e.g., `fix: <FB subject>`).
 - **Phase 7 (PR Creation)** — no new commits. The working tree MUST be clean at this point; the `pr` skill will not prompt about uncommitted changes.
 
-All commits must pass `hq:workflow` § Before Commit (format + build). Do not skip hooks.
+All commits must pass `hq:workflow` § Before Commit (format + build + blast-radius self-check). Do not skip hooks.
 
 If you discover mid-phase that an earlier commit needs fixing, prefer a new `fix:` commit over `--amend` to keep history linear and resume-safe.
 
@@ -187,7 +187,7 @@ Phase 4 runs in two modes depending on how it was entered:
 Iterate through unchecked items in the `## Plan` section of `.hq/tasks/<branch-dir>/gh/plan.md`. For **each** item:
 
 1. Implement the step.
-2. Run `format` and `build` (`hq:workflow` § Before Commit).
+2. Follow `hq:workflow` § Before Commit.
 3. Toggle the checkbox in the cache:
    ```bash
    bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-check-item.sh" "<unique substring of the item>"
@@ -206,7 +206,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-cache-push.sh" <plan>   # che
 Phase 5 has just recorded one or more failing `[auto]` items and handed them back. For each failing item:
 
 1. Analyze across **all** failing items first — shared root causes (common helper bug, missing migration, etc.) are common. Group them where possible.
-2. Apply the fix(es). Run `format` and `build`.
+2. Apply the fix(es). Follow `hq:workflow` § Before Commit.
 3. Commit per group or per fix with a `fix: ...` subject (Commit Policy).
 4. Do NOT toggle Plan checkboxes — they are already `[x]`. The Phase 5 `[auto]` checkboxes will be toggled by Phase 5 when it re-sweeps.
 
@@ -365,7 +365,7 @@ For each FB:
 1. **Classify the FB** — is it a clearly-actionable bug / typo / logic error, or a design-level / scope-ambiguous concern?
 2. **Clearly-actionable FBs — retry loop** — up to the FB retry cap times:
    1. Apply a fix.
-   2. Run `format` and `build` (`hq:workflow` § Before Commit).
+   2. Follow `hq:workflow` § Before Commit.
    3. Create a `fix: <FB subject>` commit per § Commit Policy.
    4. **Re-run the originating agent only** — the single agent that wrote this FB. Do not re-run the full Phase 6 agent set; cross-agent regression is not a Phase 6 concern (see Per-FB independence above).
    5. If the FB is gone from the re-run output, move the FB file to `feedbacks/done/` and exit the loop.

--- a/plugin/v2/docs/workflow.md
+++ b/plugin/v2/docs/workflow.md
@@ -109,7 +109,7 @@ Phase 3: Execution Prep (fresh start only)
 │  Save focus to memory
 │
 Phase 4: Execute
-│  Fresh entry: implement each Plan item (format + build + check + commit)
+│  Fresh entry: implement each Plan item (§ Before Commit + check + commit)
 │  Loopback entry (from Phase 5 fails): diagnose + fix across all failures,
 │    `fix: ...` commits, no Plan checkbox changes
 │  End (fresh): plan-cache-push.sh <plan>        [Sync: Push]

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -399,7 +399,7 @@ Skills that perform verification or review may output feedback files (FB) to `.h
 ### FB Lifecycle (for the root agent after a skill run)
 
 - Read pending FB files and assess each: fix only those that are clearly actionable (bugs, typos, logic errors). Leave design-level or scope-ambiguous FBs as-is for user judgment.
-- Run `format` and `build` commands after fixes
+- Run hq:workflow § Before Commit after fixes
 - Re-run the originating agent only to verify the specific FB is gone. Do NOT re-run the full agent set — cross-agent regression is accepted as a trade-off for review token cost
 - When an FB item is **resolved in-branch**, move its file to `feedbacks/done/`
 - When an FB item is **escalated to the PR body's `## Known Issues`** at PR creation time, move its file to `feedbacks/done/` as well — its role has shifted to the PR body (now the source of truth for residual problems)

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -16,6 +16,9 @@
 
 1. Run `format` command (see Commands table in CLAUDE.md)
 2. Verify `build` command passes
+3. **Blast-radius self-check** — one pass per unit, not a defect-exhaustion loop:
+   - For each **named thing** (symbol / heading / marker / config key / enum case / label / error code) this change introduces, renames, or shifts the semantics of, `grep` the repo and update every stale reference. LSP find-references is an equivalent substitute where available.
+   - For each procedure (gate / pipeline / phased doc / state machine) this change touches, re-read it top-to-bottom once in **flow order** and verify each step's preconditions still hold against the new state.
 
 ## Terminology
 


### PR DESCRIPTION
## Summary
PR #42 振り返りで 7 FB 中 6 件が Phase 4 実装時点で防げたはずの波及追従漏れだった知見を元に、`plugin/v2/rules/workflow.md` § Before Commit に step 3 `**Blast-radius self-check**` を追加。2 concrete actions (named thing grep + flow order 再読、1 pass per unit) を codify し、Phase 4 で agent が機械的に波及チェックを行う土台を作る。同時に `§ Before Commit` への参照 4 箇所 (start.md 63/190/209/368) と § Feedback Loop の fix 後ガイダンスを整理し、drift 余地を減らした。

## Changes
- `plugin/v2/rules/workflow.md` § Before Commit に step 3 `**Blast-radius self-check**` を追加
- `plugin/v2/rules/workflow.md` § Feedback Loop の fix 後ガイダンスを `§ Before Commit` 参照に更新
- `plugin/v2/commands/start.md` § Before Commit 参照を整理 (line 63 は 3 items 化、line 190/209/368 は `Follow hq:workflow § Before Commit` 表記に統一)
- `plugin/v2/docs/workflow.md` Phase 4 diagram の古い summary (`format + build + check + commit`) を `§ Before Commit + check + commit` に更新 (Phase 6 integrity-checker 起因の fix)

## Manual Verification
- [ ] [manual] dogfooding 観察: 本 plan merge 後、次回の /hq:start 実行時 Phase 6 所要時間が base line 24m 25s (PR #42 実測) より短縮傾向にあるか、Phase 6 FB 数が減っているかを phase-timings.jsonl と FB ディレクトリで観察。定量化は n=1 では結論出せないので「傾向」レベル

## Known Issues
- **workflow.md line 402: \`hq:workflow\` missing backtick formatting in § Feedback Loop** (FB001) — 他の全参照は backtick 付き (\`\`\`hq:workflow\`\`\`) だが本行のみ raw。Acceptance #4 の grep pattern \`"Run hq:workflow § Before Commit"\` が backtick 無しで書かれているため、rule 側に backtick を付けると acceptance signal が破れる構造的矛盾。/hq:triage で acceptance 側を書き換えるか stylistic 不整合を受容するか判断要。
- **start.md line 63: inline step summary creates a maintenance asymmetry with unified references** (FB002) — line 63 は \`(format + build + blast-radius self-check)\` と inline 列挙、line 190/209/368 は \`Follow hq:workflow § Before Commit\` に fully delegate。Plan の Impact table が両者を意図的に別扱いしているが、将来 § Before Commit の step 変更時に line 63 だけ手動更新漏れリスクあり。Full delegation への統一是非を triage で判断要。

Closes #43