### PR TITLE
feat: integrity-checker tool scope の hard-constraint 化と Downstream 宣言精度向上

### DIFF
--- a/plugin/v2/agents/integrity-checker.md
+++ b/plugin/v2/agents/integrity-checker.md
@@ -69,6 +69,26 @@ If the caller's prompt does not contain a `## Plan Sketch` block (e.g., you are 
 
 If the invocation provides no `## Plan Sketch` block at all (no plan context available), you cannot perform Impact reconciliation. Exit cleanly with a report noting "no plan context — nothing to reconcile against" and zero FB files. Do NOT substitute a broad downstream-reference sweep; the scope of this agent is reconciliation, and without a plan there is nothing in scope.
 
+## Tool Constraints
+
+`Grep` and `Glob` are powerful, but this agent's narrow scope (§ Scope above) forbids wandering the whole repository in search of general quality problems. The hard-constraints below codify scope at the tool level.
+
+**Default**: `Grep` / `Glob` MUST target paths that appear in the diff (`git diff --name-only <base>...HEAD`) — the canonical input surface for reconciliation.
+
+**Exceptions** — only two `**Impact**` table directions permit `Grep` / `Glob` to reach paths outside the diff:
+
+- **`Delete` direction residuals** — when an `**Impact**` row has `Direction = Delete`, grep the whole repo for the deleted symbol.
+  - This is the declared-but-missing detector for the `Delete` direction; remaining references after the diff mean the removal was incomplete.
+- **`Downstream` direction targeted reads** — when an `**Impact**` row has `Direction = Downstream`, read / grep the specific paths listed in that row's `Surface` column.
+  - `Downstream` permission is narrow: listed paths only, never their siblings or ancestors. Do not expand `Downstream` greps beyond the named surface.
+
+Any other `Grep` / `Glob` on paths outside the diff is a scope violation — skip it. `Add`, `Update`, and `Contradict` rows reconcile against the diff alone.
+
+**Surface classification dictionary** — `**Editable surface**` and `**Read-only surface**` are NOT just advisory prose; treat them as a classification dictionary when processing diff tokens:
+- A path in `**Editable surface**` is in-scope by declaration — reconcile against Impact rows normally.
+- A path in `**Read-only surface**` is an explicit carve-out — suppress diff-but-undeclared FBs for that path.
+- A path in neither is diff-but-undeclared — emit the FB.
+
 ## Load Criteria
 
 Read the skill file for severity classification and reporting format:

--- a/plugin/v2/agents/integrity-checker.md
+++ b/plugin/v2/agents/integrity-checker.md
@@ -133,7 +133,7 @@ Use TaskCreate and TaskUpdate to report progress so the parent session can track
      - `Update` — existing surface's contract should change in the diff (args / return / emission rule / accepted values).
      - `Delete` — surface should be removed from the diff; remaining references after the diff are FB-worthy.
      - `Contradict` — signature stable but semantics shifted; look for a diff hunk that plausibly shifts the behavior of the named surface.
-     - `Downstream` — a consumer is listed; the diff should include a coordinated update to that consumer.
+     - `Downstream` — a consumer is any referrer of the edited surface listed in this row; the diff should include a coordinated update to that consumer wherever that reference lives.
    - For each **declared Impact row**: grep the diff (and, for `Downstream` rows, the whole repo respecting exclusions) for evidence consistent with the row's `Direction`. If no evidence, emit a "declared-but-missing" FB carrying the row's `Surface` + `Direction`.
    - For each **token extracted from the diff**: check whether it corresponds to some declared Impact row (any `Direction`), or is excused by `**Read-only surface**`. If neither — diff-but-undeclared FB.
    - If the `**Impact**` table is absent from the `## Plan Sketch`, emit a single "missing Impact" FB (the plan omitted the Impact block; reconciliation cannot proceed). This is a drafting defect, not a silent skip.

--- a/plugin/v2/agents/integrity-checker.md
+++ b/plugin/v2/agents/integrity-checker.md
@@ -77,7 +77,7 @@ If the invocation provides no `## Plan Sketch` block at all (no plan context ava
 
 **Exceptions** — only two `**Impact**` table directions permit `Grep` / `Glob` to reach paths outside the diff:
 
-- **`Delete` direction residuals** — when an `**Impact**` row has `Direction = Delete`, grep the whole repo for the deleted symbol.
+- **`Delete` direction residuals** — when an `**Impact**` row has `Direction = Delete`, grep the whole repo for the deleted symbol, applying the skill's Diff Scope exclusions (`node_modules/`, build artifacts, lock files) to avoid false positives in generated output.
   - This is the declared-but-missing detector for the `Delete` direction; remaining references after the diff mean the removal was incomplete.
 - **`Downstream` direction targeted reads** — when an `**Impact**` row has `Direction = Downstream`, read / grep the specific paths listed in that row's `Surface` column.
   - `Downstream` permission is narrow: listed paths only, never their siblings or ancestors. Do not expand `Downstream` greps beyond the named surface.

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -88,9 +88,11 @@ Work interactively with the user to shape the plan. This phase is **read-only in
    - **`Update`** — an existing surface's contract changes (arguments / return shape / emission rules / accepted values).
    - **`Delete`** — an existing surface is removed.
    - **`Contradict`** — signature stable but semantics shift, potentially breaking callers silently. High-risk — flag in the `Note` column.
-   - **`Downstream`** — a consumer of the edited surface needs a coordinated update (other commands / skills / agents, docs, tests, README, templates, distribution artifacts).
+   - **`Downstream`** — a consumer is any referrer of the edited surface, and needs a coordinated update wherever that reference lives: docs, tests, templates, README, distribution artifacts (in this plugin, also other commands / skills / agents).
 
    Omit rows for directions that do not apply. Surface missing rows by asking questions, not by enumerating findings unilaterally.
+
+   **Zero-Downstream prompt**: when the `Impact` table ends with zero `Downstream` rows, ask the user how they confirmed no consumers exist — "grep で確認？ call-site list を読んだ？" — and capture the answer as a `**Constraints**` line `Downstream: none — confirmed by <check>`. This is the directive enforced in `hq:workflow § Plan Sketch § **Impact**`; Phase 2 surfaces it in the dialogue so the Constraints line never gets forgotten at Phase 3 composition time.
 
    **Downstream contract with `integrity-checker`**: the finalized `**Impact**` table is the structured input `/hq:start` Quality Review hands to the `integrity-checker` agent — alongside `**Problem**`, `**Editable surface**`, `**Read-only surface**`, and `**Constraints**`. `**Core decision**` and `**Change Map**` are NOT passed. The agent reconciles each declared row against the diff; both "declared-but-missing" and "diff-but-undeclared" become FBs. Under-populating Impact means under-inspection at review time; over-populating with aspirational rows produces false "declared-but-missing" FBs. Honesty over coverage theater.
 

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -163,7 +163,7 @@ Parent: #<hq:task issue number>
 
   **Downstream check directive** — when the `**Impact**` table contains zero `Downstream` rows, the plan MUST include a line `Downstream: none — confirmed by <specific check>` under `**Constraints**`. Forces the author to name the concrete check that confirmed no consumers exist (e.g., `grep -rn "<identifier>" .`, reading the call-site list), so silent omissions become auditable declarations.
 - **`**Core decision**`** *(required)* — 1-2 sentences on the key architectural choice. If there is no genuine decision to highlight, the plan probably does not need a `## Plan Sketch` at all.
-- **`**Constraints**`** *(optional)* — hard dependencies, prerequisites, or assumptions. Omit when genuinely empty.
+- **`**Constraints**`** *(optional except when required by the Downstream check directive above)* — hard dependencies, prerequisites, or assumptions. Omit when genuinely empty.
 
 ### `## Plan`
 

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -157,9 +157,11 @@ Parent: #<hq:task issue number>
   - **`Update`** — an existing surface's contract changes (arguments, return shape, emission rules, accepted values).
   - **`Delete`** — an existing surface is removed.
   - **`Contradict`** — the surface's signature is stable but its semantics shift, potentially breaking existing callers silently. These are the highest-risk entries — flag them clearly in the `Note` column.
-  - **`Downstream`** — a consumer of the edited surface needs a coordinated update (docs, tests, other commands / skills / agents, README, templates, distribution artifacts).
+  - **`Downstream`** — a consumer is any referrer of the edited surface, and needs a coordinated update wherever that reference lives: docs, tests, templates, README, distribution artifacts (in this plugin, also other commands / skills / agents).
 
   Omit rows for directions that do not apply. If all 5 directions would be empty, the change is trivial and the `**Impact**` block itself can be skipped.
+
+  **Downstream check directive** — when the `**Impact**` table contains zero `Downstream` rows, the plan MUST include a line `Downstream: none — confirmed by <specific check>` under `**Constraints**`. Forces the author to name the concrete check that confirmed no consumers exist (e.g., `grep -rn "<identifier>" .`, reading the call-site list), so silent omissions become auditable declarations.
 - **`**Core decision**`** *(required)* — 1-2 sentences on the key architectural choice. If there is no genuine decision to highlight, the plan probably does not need a `## Plan Sketch` at all.
 - **`**Constraints**`** *(optional)* — hard dependencies, prerequisites, or assumptions. Omit when genuinely empty.
 


### PR DESCRIPTION
## Summary
`/hq:start` Phase 6 Quality Review の時間律速を解消するため、integrity-checker agent の tool scope を hard-constraint 化し、plan 起草段階での `Downstream` 宣言漏れを防ぐ directive を追加した。agent 側と起草側の両輪で codify することで「declared → agent が mechanical に verify」の循環を成立させる。

## Changes
- `plugin/v2/agents/integrity-checker.md` に `## Tool Constraints` section を追加。`Grep`/`Glob` の diff 範囲外 scan を `Delete` 行の残骸検出と `Downstream` 行の targeted read の 2 例外のみに制限。`**Editable surface**` / `**Read-only surface**` を分類辞書として使う旨も明記。
- `plugin/v2/rules/workflow.md § Plan Sketch § **Impact**` に Downstream check directive を追加。`Downstream` 行が 0 件なら `**Constraints**` に `Downstream: none — confirmed by <check>` の 1 行必須化。同節内の `Downstream` 定義例示を "any referrer of the edited surface" 起点の汎用 → 固有順に refactor。
- `plugin/v2/commands/draft.md` の `Downstream` 定義例示を workflow.md と同じ表記に refactor し、Phase 2 step 6 対話フローに zero-Downstream prompt を追加。

Review feedback による追加修正:
- workflow.md の `**Constraints**` optionality marker を directive に整合させて qualify (H1)
- integrity-checker.md の Delete direction whole-repo grep に Diff Scope exclusions 注記を追加 (M1)
- integrity-checker.md Execution Flow の Downstream 表現を refactor 後の canonical wording と一致させる (M3)

## Manual Verification
- [ ] [manual] dogfooding 観察: 次回 /hq:start 実行時、integrity-checker の tool_uses 数が base line 64 (PR #44 実測) より顕著に減少し、Phase 6 所要時間も base line 9m 16s より短縮傾向にあるかを agent report および phase-timings.jsonl から観察。n=1 なので傾向レベル

## Known Issues
- escalated: #47
- **FB004 (Medium)** — Downstream Surface column の prose description から file path を解決する parsing rule が未定義。現状 LLM の推論に委ねられており、"never siblings or ancestors" の narrow rule と乖離するリスク。scope-ambiguous。
- escalated: #48

Closes #45