### PR TITLE
feat: /hq:draft Phase 構造刷新と Simplicity gatekeeper 内在化

### DIFF
--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -191,7 +191,7 @@ Before emitting the Issue, run the hard rule from `hq:workflow § Simplicity Cri
 - For each row, locate at least one `## Plan` item that performs the coordinated update on the named consumer. Pattern-match on the consumer identifier (file path, symbol name, section header).
 - If a `Downstream` row has no covering `## Plan` item, **do not emit**. Three paths out:
   1. The row is aspirational (you speculated about a consumer but will not actually touch it) → delete the row.
-  2. The Plan is genuinely incomplete → return to Phase 2, brainstorm the missing Plan item, then **re-present the Phase 3 point-check with the updated state**, await a fresh "go", and re-enter Phase 4.
+  2. The Plan is genuinely incomplete → **reset** "Present point-check" from `completed` back to `in_progress` and "Brainstorm + Simplicity gatekeeper" to `in_progress` (both via `TaskUpdate`), return to Phase 2, brainstorm the missing Plan item, then **re-present the Phase 3 point-check with the updated state**, await a fresh "go", and re-enter Phase 4. The reset keeps Progress Tracking consistent with Phase 3's own lifecycle rule for 違和感 loopbacks — without it the UI would show "Present point-check" as `completed` while the phase is actively re-running.
   3. The row belongs in `**Read-only surface**` (it was investigated and deliberately not modified) → move it there and — when the intent is to record the verification rationale — add a matching `**Constraints**` line.
 
 Paths 1 and 3 are mechanical reclassifications that do not add new work or new commitments, so they do not require a Phase 3 re-run. Path 2 materially changes the brainstormed plan and therefore always triggers a new Phase 3 point-check per the `Any Phase 2 loopback re-runs Phase 3` rule in `## Rules`.

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -101,6 +101,8 @@ These are the fields that must be committable before Phase 3. Track them as you 
 - **Minimum-solution comparison** — what does "do nothing" or "a small hack" look like, and does it cover the critical case? If the minimum solution already covers the real need, flag the delta to the permanent solution.
 - **Spread cost** — estimate how many other commands / skills / rules / doc pages a proposal will require conditionals in. High spread count → high Simplicity bar.
 - **`[auto]` / `[manual]` marker — domain judgment by Claude.** The marker on the primary acceptance is a **domain** decision, not a user choice. Pick it based on the plan's domain: web feature drivable by `/hq:e2e-web` → `[auto]`; native iOS / subjective UX / physical device → `[manual]` escape hatch (`hq:workflow § #### [manual] [primary] escape hatch`); doc / config / rule-text → `[auto]` via grep / file-existence. Do not present the marker as a question to the user; commit to it in Phase 3.
+
+  **Before committing `[manual]`, verify all three escape hatch conditions hold** (`hq:workflow § #### [manual] [primary] escape hatch`): (a) `[auto]` outcome measurement is structurally infeasible in this domain — not merely inconvenient; web features that `/hq:e2e-web` can drive do **not** qualify, (b) the primary names exactly one concrete observable target (UI state name, interaction terminus, visual / sound target, named artifact) — abstract phrases are rejected under the escape hatch just as they are under the default, (c) the `**Impact**` table is fully declared (every populated `Direction` row present). If any condition fails, revert to `[auto]`; if `[auto]` is genuinely infeasible but the primary is abstract, continue Phase 2 until condition (b) holds.
 - **Plan split judgment** — when the scope emerging from the brainstorm is naturally broad, ask whether it should become **multiple `hq:plan`s** rather than one. No numeric cap — the question is whether the concerns are genuinely independent commit grains.
 
 **Pushback protocol** — raise each gate concern **at most once** per concern. Name the issue, state the tradeoff, let the user decide. Do not keep re-arguing after the user has made the call. Tradeoffs the user accepts after pushback are recorded verbatim in `**Core decision**` (e.g., "A を採用 — B の複雑性を引き受ける、理由: C") so PR reviewers can see the decision was deliberate, not accidental.
@@ -118,7 +120,8 @@ Phase 2 exits when **all** of the following are committable — each one, Claude
 - `**Problem**` — a crisp 1–3 sentence statement.
 - `**Core decision**` — a crisp 1–2 sentence statement.
 - The `**Editable surface**` set (files / symbols definitely in play).
-- The adjacent / `Downstream`-candidate surface set.
+- The `**Read-only surface**` set (adjacent files / symbols explicitly declared out of scope — see `hq:workflow § ## Plan Sketch`; the set is populated in Phase 4 by splitting the adjacent-surface list into `Downstream` rows vs `**Read-only surface**` entries, but Phase 2 must have a committable view of what is deliberately **not** in scope before the point-check).
+- The adjacent / `Downstream`-candidate surface set (raw investigation output, classified in Phase 4).
 - `**Primary acceptance**` with marker, committed as a single concrete signal.
 - Plan split judgment (one plan vs several).
 
@@ -166,6 +169,10 @@ Autonomous from here. Compose the `hq:plan` body directly from Phase 2 conversat
 
 - **Language** — plan body prose stays in the **conversation language** (`**Problem**` prose, Impact table cells, `## Plan` step descriptions, `## Acceptance` conditions). Workflow markers and prescribed headings stay in **English** — see `hq:workflow § Language`.
 - **Anti-filler** — optional subfields (`**Change Map**`, `**Constraints**`, unused `Direction` rows) are omitted entirely when genuinely empty. No `_None._`, no padded prose. If a required subfield would be empty, Phase 2 did not converge — return control to Phase 2.
+- **Classify adjacent surface** — for each entry in the Phase 2 "調査で当たった隣接範囲" list (the raw investigation output shown in the Phase 3 point-check), decide one of two outcomes:
+  - **This plan will actively update the consumer** → record as a `Downstream` row in the `**Impact**` table. A covering `## Plan` item is required (the Downstream coverage hard rule below enforces this).
+  - **This plan will deliberately NOT modify the consumer** → record the consumer in `**Read-only surface**`. No Plan item is required; the row is explicitly out of scope.
+  Every adjacent surface row reaches exactly one of these two destinations. A row that lands in neither is a misclassification — do not silently drop findings.
 - **`Parent: #N` line** — emit only when a parent `hq:task` is present; omit the line entirely otherwise.
 - **`## Plan` granularity** — each item is a single meaningful commit unit (`hq:workflow § ## Plan`). No numeric cap. Adjacent edits to the same file in one session collapse into one item; half-working intermediate states are a split defect.
 - **`[primary]` rule** — exactly one `[primary]` item in `## Acceptance`. Default combination is `[auto] [primary]`; `[manual] [primary]` is permitted only when the `hq:workflow § #### [manual] [primary] escape hatch` conditions all hold (structurally infeasible `[auto]` outcome, single named observable target, fully declared `**Impact**`). The marker was chosen by Claude in Phase 2 by domain.
@@ -184,10 +191,14 @@ Before emitting the Issue, run the hard rule from `hq:workflow § Simplicity Cri
 - For each row, locate at least one `## Plan` item that performs the coordinated update on the named consumer. Pattern-match on the consumer identifier (file path, symbol name, section header).
 - If a `Downstream` row has no covering `## Plan` item, **do not emit**. Three paths out:
   1. The row is aspirational (you speculated about a consumer but will not actually touch it) → delete the row.
-  2. The Plan is genuinely incomplete → return to Phase 2, brainstorm the missing Plan item, then re-enter Phase 4.
-  3. The row belongs in `**Read-only surface**` (it was investigated and deliberately not modified) → move it.
+  2. The Plan is genuinely incomplete → return to Phase 2, brainstorm the missing Plan item, then **re-present the Phase 3 point-check with the updated state**, await a fresh "go", and re-enter Phase 4.
+  3. The row belongs in `**Read-only surface**` (it was investigated and deliberately not modified) → move it there and — when the intent is to record the verification rationale — add a matching `**Constraints**` line.
+
+Paths 1 and 3 are mechanical reclassifications that do not add new work or new commitments, so they do not require a Phase 3 re-run. Path 2 materially changes the brainstormed plan and therefore always triggers a new Phase 3 point-check per the `Any Phase 2 loopback re-runs Phase 3` rule in `## Rules`.
 
 Only when every `Downstream` row has a covering `## Plan` item may Phase 4 emit.
+
+**Zero-Downstream case (symmetric)** — when the `**Impact**` table contains **zero** `Downstream` rows (after the classification step above), the `**Constraints**` block MUST contain a line of the form `Downstream: none — confirmed by <specific check>` (e.g., `Downstream: none — confirmed by grep -rn "<identifier>" .` or `Downstream: none — confirmed by reading all call sites`). This is the `hq:workflow § ## Plan Sketch § **Impact** § Downstream check directive` — it forces auditable declaration rather than silent omission. If this Constraints line is absent, return to Phase 2, establish the check, then re-present the Phase 3 point-check before re-entering Phase 4.
 
 ### Required plan body shape
 
@@ -294,7 +305,9 @@ The handoff boundary is intentional — the user reviews and edits the `hq:plan`
 
 - **No code writing** — planning-only. Redirect implementation requests to `/hq:start <plan>` after Issue creation.
 - **No branch creation** — `/hq:start` owns branch creation.
-- **Phase 2 convergence is a commitment** — all fields listed under *Exit condition* must be committable (Problem, Core decision, Editable / adjacent surfaces, primary with marker, plan split judgment). Handing a hedging-qualifier-attached field to Phase 3 is forbidden — the point-check is a position, not a menu.
+- **Phase 2 convergence is a commitment** — all fields listed under *Exit condition* must be committable (Problem, Core decision, Editable / Read-only / adjacent surfaces, primary with marker, plan split judgment). Handing a hedging-qualifier-attached field to Phase 3 is forbidden — the point-check is a position, not a menu.
+- **Phase 3 point-check requires explicit "go"** — Phase 4 does not start until the user endorses the point-check with "go", "OK", "LGTM", or equivalent. Proceeding to Phase 4 without this signal — including under auto mode (see the Auto-mode note at the top) — violates this command's contract. This is the single sanctioned user intervention between brainstorm and autonomous composition, successor to the old Recap-approval gate.
+- **Any Phase 2 loopback re-runs Phase 3** — when Phase 4 (or any subsequent step) returns to Phase 2 for further brainstorm, the next forward motion MUST re-present the Phase 3 point-check and await a fresh "go" before Phase 4 re-enters. The user's prior endorsement covers only the state of the brainstorm at the time of that point-check.
 - **Simplicity gatekeeper is active** — Phase 2 raises reuse / minimum-solution / spread-cost concerns once per concern and records accepted tradeoffs in `**Core decision**`. Silent transcription of the user's proposal without the gate is out of scope.
 - **Downstream pre-emit check is a hard rule** — Phase 4 does not emit an Issue with uncovered `Downstream` rows (`hq:workflow § Downstream coverage hard rule`).
 - **Marker choice is Claude's domain judgment** — `[auto]` vs `[manual]` for the primary is not asked of the user; Claude decides from the domain in Phase 2.

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -158,8 +158,8 @@ Shape rules:
 
 ### User response handling
 
-- **"go"** (or equivalent endorsement: "OK", "LGTM", "進めて") → proceed to Phase 4.
-- **違和感** pointed out → return to Phase 2; resume the dialogue from the specific block the user questioned. Do not re-present a revised point-check as a counter-offer; continue the brainstorm until convergence, then re-present once.
+- **"go"** (or equivalent endorsement: "OK", "LGTM", "進めて") → mark the "Present point-check" task as `completed` (via `TaskUpdate`) before starting Phase 4, then proceed to Phase 4. This closes the task cleanly whether the point-check was presented once (go on first attempt) or re-presented after a prior 違和感 loopback.
+- **違和感** pointed out → keep the "Present point-check" task `in_progress`, return to Phase 2 (marking "Brainstorm + Simplicity gatekeeper" `in_progress` again); resume the dialogue from the specific block the user questioned. Do not re-present a revised point-check as a counter-offer; continue the brainstorm until convergence, then re-present once.
 
 ## Phase 4: Compose plan body + Downstream pre-emit check
 

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -1,25 +1,31 @@
 ---
 name: draft
-description: Interactive brainstorm → create an hq:plan Issue (optionally from an hq:task)
+description: Exploration-led brainstorm + Simplicity gatekeeper → create an hq:plan Issue (optionally from an hq:task)
 allowed-tools: Read, Glob, Grep, Bash(git:*), Bash(gh:*), Bash(bash:*), Bash(mkdir:*), TaskCreate, TaskUpdate
 ---
 
 # DRAFT — Brainstorm & Create `hq:plan`
 
-This command creates an `hq:plan` Issue (implementation plan). It runs in two modes:
-
-- **Parented mode** — invoked with an `hq:task` Issue number: `/hq:draft <issue-number>`. The plan links back to the `hq:task` as its parent.
-- **Standalone mode** — invoked without arguments: `/hq:draft`. The plan is a top-level Issue with no parent `hq:task`; the requirement is captured in the plan's `## Plan Sketch` / `**Problem**` block.
-
-It is the **first half** of the two-command workflow:
+This command creates an `hq:plan` Issue (implementation plan). It is the **first half** of the two-command workflow:
 
 ```
 [hq:task (optional)] --/hq:draft--> hq:plan --/hq:start--> PR
 ```
 
-User intervention points for this command: (1) the interactive brainstorm in Phase 2, (2) the user's explicit "go" signal to transition from brainstorm to autonomous Issue creation. After "go", everything runs to completion without further prompts.
+The command accepts an optional `hq:task` Issue number. When provided, the resulting plan is linked back to that task (`Parent: #N` emitted, sub-issue registered, milestone / project inherited). When absent, the plan is top-level and the requirement is captured in its own `## Plan Sketch` / `**Problem**` block. This is a single input variable, not a "mode" — every conditional below is written as "when a parent `hq:task` exists" / "when absent", not as parented / standalone dichotomy.
 
-**Auto-mode note**: Claude Code's "auto mode" is a session-wide directive to minimize interruptions and prefer action over planning. **This directive does NOT apply to `/hq:draft` Phase 2.** The brainstorm is one of the two sanctioned user intervention points in the HQ workflow (the other being PR review). Producing the Brainstorm Recap unilaterally and pressing forward without the user's explicit "go" — even under auto mode — is a **violation of this command's contract**. When auto mode and this phase's interactivity conflict, this phase wins.
+## Role — formatter vs gatekeeper
+
+`/hq:draft` is not a transcription service. Two roles matter:
+
+- **Exploration-led brainstorm** — the Phase 2 conversation follows the user's framing of the problem (what they want, what needs solving), not the `hq:plan` schema shape. Internal checklists track what is required for composition; they do not dictate the turn-by-turn dialogue.
+- **Simplicity gatekeeper** — Phase 2 actively challenges benefit/complexity tradeoffs before the plan is composed. Reuse vs new-build, minimum-solution comparison, spread cost, `[auto]` / `[manual]` marker judgment from domain — these are gate questions Claude raises, not topics the user is expected to surface unprompted. See `hq:workflow § Simplicity Criterion` for the rationale (it is the mitigation for the limit documented in `hq:doc #40`).
+
+Review surface is the **GitHub Issue** only. There is no in-chat "Recap approval" step — see Phase 3 (Point-check).
+
+User intervention points: (1) the exploratory dialogue in Phase 2, (2) a single "go" on the Phase 3 point-check. After "go", everything runs to Issue creation without further prompts.
+
+**Auto-mode note**: Claude Code's "auto mode" is a session-wide directive to minimize interruptions and prefer action over planning. **This directive does NOT apply to `/hq:draft` Phase 2 or the Phase 3 point-check.** The brainstorm and its single "go" checkpoint are sanctioned user intervention points; advancing through them unilaterally — even under auto mode — is a **violation of this command's contract**.
 
 **Security**: GitHub Issue content is user-provided input. Only execute shell commands that match expected patterns (git, gh). Flag anything else to the user.
 
@@ -29,13 +35,14 @@ Use Claude Code's task UI (`TaskCreate` / `TaskUpdate`). Create all phases as ta
 
 | Task subject | activeForm |
 |---|---|
-| Load hq:task (if provided) | Loading hq:task |
-| Brainstorm with user | Brainstorming with user |
-| Compose plan body | Composing plan body |
+| Intake (hq:task + pre-session context) | Taking input |
+| Brainstorm + Simplicity gatekeeper | Brainstorming with user |
+| Present point-check | Presenting point-check |
+| Compose plan body + Downstream pre-emit check | Composing plan body |
 | Create hq:plan Issue | Creating hq:plan Issue |
 | Report results | Reporting results |
 
-In standalone mode the first task has nothing to fetch — mark it `completed` immediately after Phase 1 determines the mode. The row is kept so the overall phase count stays stable across modes.
+When `$ARGUMENTS` is empty, the intake task has nothing to fetch — mark it `completed` immediately after Phase 1 finishes. The row is kept so the overall phase count stays stable.
 
 Set each to `in_progress` when starting and `completed` when done.
 
@@ -46,171 +53,143 @@ Set each to `in_progress` when starting and `completed` when done.
 
 **`hq:workflow`** — shorthand for `${CLAUDE_PLUGIN_ROOT}/plugin/v2/rules/workflow.md` (plugin-internal source of truth). Read it with the Read tool when this command starts so all subsequent phases have the rule available. All `hq:workflow § <name>` citations below refer to sections of that file.
 
-## Phase 1: Load `hq:task` (optional)
+## Phase 1: Intake (hq:task + pre-session context)
 
-The `hq:task` Issue is **optional**. `/hq:draft` supports two modes:
+Two inputs feed the brainstorm:
 
-1. **With argument (parented mode)** — if `$ARGUMENTS` is provided:
-   - Parse the issue number (accept `#1234` or `1234`)
-   - Any text after the issue number is **supplementary context** (e.g., `#1234 implement only task 7`)
-   - Fetch the issue: `gh issue view <number> --json title,body,milestone,labels,projectItems`
-   - Verify it has the `hq:task` label. If not, warn the user but continue.
-   - If the issue has the `hq:wip` label, warn the user: "This issue has the `hq:wip` label — it seems to be still under discussion. Do you want to proceed anyway?" — if the user declines, stop.
-   - Conversation state: `hq:task` is present.
+**`hq:task` Issue (optional)** — when `$ARGUMENTS` is provided:
 
-2. **No argument (standalone mode)** — run without an `hq:task`:
-   - Do NOT ask the user for an Issue number. Skip the `hq:task` fetch entirely.
-   - Conversation state: `hq:task` is absent (`null`). Downstream phases branch on this.
-   - The plan's `## Plan Sketch` / `**Problem**` becomes the sole source of truth for the requirement — Phase 2 will ensure the block is substantively populated before advancing to Phase 3.
-   - Phase 2 will open by asking the user what the plan is about (title / topic). No prompt is issued in Phase 1.
+- Parse the issue number (accept `#1234` or `1234`).
+- Any text after the issue number is **supplementary context** (e.g., `#1234 implement only task 7`).
+- Fetch the issue: `gh issue view <number> --json title,body,milestone,labels,projectItems`.
+- Verify the `hq:task` label. If absent, warn the user but continue.
+- If the `hq:wip` label is present, warn: "This issue has the `hq:wip` label — it seems to be still under discussion. Do you want to proceed anyway?" — if the user declines, stop.
 
-Keep the fetched task data (title, body, milestone, labels, projects) and the supplementary context in conversation state **when in parented mode**. In standalone mode, there is no task data to keep. **Do not** write the cache yet — the cache is created after the feature branch exists (which happens in `/hq:start`, not here).
+When `$ARGUMENTS` is empty, do **not** ask the user for an Issue number. Skip the fetch entirely; the requirement will be captured in Phase 2 and materialize as the plan's `## Plan Sketch § **Problem**`.
 
-## Phase 2: Brainstorm (interactive — MUST pause for user)
+**Pre-session conversation context** — the conversation history that precedes the `/hq:draft` invocation (files read, code investigated, topics discussed) is carried forward into Phase 2 as brainstorm material. This matters most when no `hq:task` is provided — the user has often already done the working session's exploration, and Phase 2 should not restart from a blank slate by asking "what's your topic?". Instead, open Phase 2 by summarizing what you understood from the pre-session context and asking the user to confirm or correct it.
 
-**This phase REQUIRES user interaction.** It runs as an iterative back-and-forth between Claude and the user. Claude MUST NOT produce the Brainstorm Recap and proceed to Phase 3 unilaterally — doing so defeats the purpose of the command. Even when auto mode is active (see **Auto-mode note** at the top of this command), Phase 2 MUST pause for user input; the explicit "go" signal on the recap is non-negotiable.
+Keep the fetched task data (title, body, milestone, labels, projects), any supplementary text from `$ARGUMENTS`, and your read of the pre-session context in conversation state. **Do not** write the local cache yet — the cache is created after the feature branch exists (which happens in `/hq:start`, not here).
 
-Work interactively with the user to shape the plan. This phase is **read-only investigation**:
+## Phase 2: Brainstorm + Simplicity gatekeeper (interactive — MUST pause for user)
 
-0. **Standalone mode only** — if Phase 1 ended in standalone mode, open Phase 2 by asking the user for a short topic or working title. Skipped in parented mode — the `hq:task` already supplies the starting topic.
-1. Review the starting material together — the `hq:task` issue content (parented mode) or the user-supplied topic (standalone mode).
-2. Discuss what the user wants to achieve — use the supplementary context (parented mode) or the user's own framing (standalone mode) to narrow scope.
-3. Investigate relevant code: read files, grep the codebase, understand current state.
-4. Align on scope and approach at a high level.
-5. **Enumerate `Editable surface` / `Read-only surface`** — walk the user through what the plan MAY touch and what it MUST NOT. Both are required in the resulting `## Plan Sketch`; the symmetric pair closes "what's in play" vs "what stays put". Ask:
-   - "Which files / symbols does this plan modify?" → `Editable surface`.
-   - "Which adjacent files / symbols look related but should NOT be modified by this plan?" → `Read-only surface`.
+**This phase REQUIRES user interaction.** The dialogue is **exploration-led**, not schema-led: track what `hq:plan` composition will need in an internal checklist, but drive the conversation by the user's framing of the problem — what they want to achieve, what obstacles they see, what trade-offs they are weighing. Producing the Phase 3 point-check without a genuine brainstorm first — even under auto mode (see **Auto-mode note** at the top) — is a contract violation.
 
-   Read-only is not "files the world at large doesn't touch" — it is files the user might reasonably assume are in play but aren't. Include the adjacent risk surface.
+This phase is **read-only investigation**. Do NOT write production code.
 
-6. **Fill the `Impact` table** — for each item in `Editable surface`, record a row in the 4-column table (`Direction` / `Surface` / `Kind` / `Note`). The `Direction` column uses a closed set of 5 values:
-   - **`Add`** — a new surface is introduced (new function / field / command / config key / section / label / file).
-   - **`Update`** — an existing surface's contract changes (arguments / return shape / emission rules / accepted values).
-   - **`Delete`** — an existing surface is removed.
-   - **`Contradict`** — signature stable but semantics shift, potentially breaking callers silently. High-risk — flag in the `Note` column.
-   - **`Downstream`** — a consumer is any referrer of the edited surface, and needs a coordinated update wherever that reference lives: docs, tests, templates, README, distribution artifacts (in this plugin, also other commands / skills / agents).
+### Conversation entry
 
-   Omit rows for directions that do not apply. Surface missing rows by asking questions, not by enumerating findings unilaterally.
+- When a parent `hq:task` was fetched in Phase 1, start from its body.
+- When no parent was fetched, open by summarizing what you picked up from the **pre-session conversation context** and asking the user to confirm or correct ("Here's what I understood you are trying to solve — is that right?"). Do not ask the user to restate the topic from scratch.
 
-   **Zero-Downstream prompt**: when the `Impact` table ends with zero `Downstream` rows, ask the user how they confirmed no consumers exist — "grep で確認？ call-site list を読んだ？" — and capture the answer as a `**Constraints**` line `Downstream: none — confirmed by <check>`. This is the directive enforced in `hq:workflow § Plan Sketch § **Impact**`; Phase 2 surfaces it in the dialogue so the Constraints line never gets forgotten at Phase 3 composition time.
+### Internal checklist (track silently; do not turn into a turn-by-turn script)
 
-   **Downstream contract with `integrity-checker`**: the finalized `**Impact**` table is the structured input `/hq:start` Quality Review hands to the `integrity-checker` agent — alongside `**Problem**`, `**Editable surface**`, `**Read-only surface**`, and `**Constraints**`. `**Core decision**` and `**Change Map**` are NOT passed. The agent reconciles each declared row against the diff; both "declared-but-missing" and "diff-but-undeclared" become FBs. Under-populating Impact means under-inspection at review time; over-populating with aspirational rows produces false "declared-but-missing" FBs. Honesty over coverage theater.
+These are the fields that must be committable before Phase 3. Track them as you listen; when a field is still fuzzy, ask about it as a natural continuation of the current thread — not as a checklist item.
 
-7. **Identify `Primary acceptance`** — ask the user: "if exactly one verification passes, which one tells us the plan succeeded?"
+- `**Problem**` — 1–3 sentences naming the pain and why now.
+- `**Editable surface**` — files / symbols that will definitely be touched.
+- Adjacent surface discovered by investigation — files / symbols investigation surfaces as potentially impacted, for Phase 3's "調査で当たった隣接範囲" block and the final `**Impact**` table's `Downstream` rows.
+- `**Core decision**` — 1–2 sentences on the key architectural choice. Record here any tradeoff accepted after Simplicity gatekeeper pushback.
+- `**Primary acceptance**` with marker (`[auto]` or `[manual]`) — see Primary acceptance convergence below.
+- Plan scope size estimate — is this one plan or better split into several?
 
-   **Default path (`[auto] [primary]`)** — the answer must be **concrete and machine-verifiable** (`[auto]`-compatible) — not abstract prose. It becomes the single `[auto] [primary]` Acceptance item in the plan. Browser features qualify for `[auto]` via `/hq:e2e-web` (Playwright). Keep probing if the first answer is abstract; a plan without a clear primary is a drafting defect, not an acceptable state.
+### Simplicity gate (Claude applies actively — gate, not commentary)
 
-   **Escape hatch branch (`[manual] [primary]`)** — triggered when `[auto]` outcome measurement is structurally infeasible in the plan's domain. Canonical cases: native mobile UI behavior (iOS / Android touch interactions, platform-specific animations), subjective UX / visual design targets, multi-session scenarios outside Playwright's reach. **Web features where `/hq:e2e-web` can drive the outcome do NOT qualify** — stay on the default path. See `hq:workflow § #### [manual] [primary] escape hatch` for the full conditions and compensating controls.
+`/hq:draft` holds the role `hq:workflow § Simplicity Criterion` describes. Raise these gate questions whenever the conversation suggests a non-trivial addition. Do NOT silently transcribe the user's proposal into the plan if a gate concern applies — surface it.
 
-   When the escape hatch applies, pivot the dialogue to elicit a single **observable event**:
+- **Reuse vs new-build** — can an existing mechanism be extended, combined, or slightly reshaped to achieve the same outcome? If yes, push back on the net-new path.
+- **Minimum-solution comparison** — what does "do nothing" or "a small hack" look like, and does it cover the critical case? If the minimum solution already covers the real need, flag the delta to the permanent solution.
+- **Spread cost** — estimate how many other commands / skills / rules / doc pages a proposal will require conditionals in. High spread count → high Simplicity bar.
+- **`[auto]` / `[manual]` marker — domain judgment by Claude.** The marker on the primary acceptance is a **domain** decision, not a user choice. Pick it based on the plan's domain: web feature drivable by `/hq:e2e-web` → `[auto]`; native iOS / subjective UX / physical device → `[manual]` escape hatch (`hq:workflow § #### [manual] [primary] escape hatch`); doc / config / rule-text → `[auto]` via grep / file-existence. Do not present the marker as a question to the user; commit to it in Phase 3.
+- **Plan split judgment** — when the scope emerging from the brainstorm is naturally broad, ask whether it should become **multiple `hq:plan`s** rather than one. No numeric cap — the question is whether the concerns are genuinely independent commit grains.
 
-   - Ask: "`[auto]` / `[manual]` を問わず、この plan が達成したい本質ゴールを **1 つの観察可能事象** で表すと何？" (adapt to the conversation language).
-   - If the user answers with an abstract phrase ("works correctly", "user is satisfied", "animation is smooth", "app launches"), drill down: "その時 reviewer が見る事象は 1 つに絞ると何？ UI state の名前 / interaction の結末 / visual target / sound target のいずれかを 1 つ名指しで".
-   - Acceptable answers name a single observable target: UI state name, interaction terminus, named artifact, visual / sound target.
-   - When a concrete observable is given, verify the three escape hatch conditions hold: (a) `[auto]` outcome genuinely infeasible in this domain, (b) primary names one observable event with a concrete target, (c) `**Impact**` table is fully declared. If all hold, the item becomes `[manual] [primary]` in the plan. If any fails, return to the default path.
+**Pushback protocol** — raise each gate concern **at most once** per concern. Name the issue, state the tradeoff, let the user decide. Do not keep re-arguing after the user has made the call. Tradeoffs the user accepts after pushback are recorded verbatim in `**Core decision**` (e.g., "A を採用 — B の複雑性を引き受ける、理由: C") so PR reviewers can see the decision was deliberate, not accidental.
 
-   Tell the user the downstream contract: `[manual] [primary]` obligates the PR to carry a `## Primary Verification (manual)` evidence block (screenshot / video + reviewer checklist of ≥3 observations) and the `hq:manual` label — enforced by `/hq:start` Phase 7 gate.
+### Primary acceptance convergence
 
-8. Identify what else can be auto-verified (`[auto]`) vs what needs the user's eyes (`[manual]`).
+`**Primary acceptance**` is the single observable signal that tells the plan succeeded. It is a **Phase 2 convergence requirement**: Phase 2 does not exit until Claude can commit — with confidence — to one concrete primary with its marker. An abstract phrase ("feature works") is a non-converged state, not an acceptable primary. Keep the brainstorm open until the conversation has produced a signal you would bet the plan on.
 
-9. **Sketch `## Plan` grain** — roughly count how many independent commit-units the change spans. Target **1-5 ideal, 10 upper bound**. If the count is trending past 10, discuss with the user whether items can be merged (especially adjacent edits to the same file) before proceeding. This is the moment to catch step-by-step-instruction-manual drift before it becomes 30 commits.
+Converged means **committable**: Claude writes the primary as one line with its `[auto]` or `[manual]` marker chosen by domain, and stands by it. Hedging qualifiers (parenthesized disclaimers, "tentative", "one possibility") are not permitted on the primary — either it has converged (commit it) or it has not (keep brainstorming).
 
-Drive these steps through **dialogue** — ask the user questions, surface findings, check understanding. Do NOT sequence through them as a monologue. A productive Phase 2 typically spans several back-and-forth turns.
+### Exit condition
 
-Example prompts — adapt to the conversation language (these are English for authoring consistency; use as inspiration, not a script):
-- "Which files / symbols does this plan modify? Which adjacent ones are read-only?"
-- "For each modified surface — is it `Add` / `Update` / `Delete` / `Contradict` / `Downstream`?"
-- "If one check had to certify 'the plan is done', which one would it be?"
-- "Can any of these steps be merged — any two that edit the same file in the same session?"
+Phase 2 exits when **all** of the following are committable — each one, Claude is ready to endorse and present as a decision rather than as an option:
 
-**Do NOT write production code.** This phase is purely investigation and alignment.
+- `**Problem**` — a crisp 1–3 sentence statement.
+- `**Core decision**` — a crisp 1–2 sentence statement.
+- The `**Editable surface**` set (files / symbols definitely in play).
+- The adjacent / `Downstream`-candidate surface set.
+- `**Primary acceptance**` with marker, committed as a single concrete signal.
+- Plan split judgment (one plan vs several).
 
-### Brainstorm Recap
+If any of these is fuzzy, Phase 2 is not converged — continue the dialogue. Handing a fuzzy set to Phase 3 is forbidden; the point-check is a commitment, not a menu of options.
 
-Only after the investigation + dialogue above has converged on shared understanding, produce a structured recap and **present it to the user for confirmation**. Do NOT skip the dialogue and jump straight to the Recap — the Recap is the *output* of a completed brainstorm, never a *substitute* for it. The recap maps 1-to-1 to the Phase 3 output schema.
+## Phase 3: Point-check (Claude's decisive recommendation)
+
+Phase 3 is a single in-chat checkpoint: three blocks of committed recommendations presented once; user response is a binary — **endorse ("go")** or **raise a 違和感 and return to Phase 2**. There is no schema-draft approval gate, and no hedging qualifier on any block — every block is a position Claude stands by. Full-body plan review happens on the GitHub Issue after Phase 5, not here.
+
+Present exactly this structure (adapt block content to the conversation language; keep block labels as shown):
 
 ```markdown
-### Brainstorm Recap
+## 見立て
 
-**Problem** — <1-3 sentences>
-
-**Editable surface**
+**確実に触る**
 - <file / symbol>
 
-**Read-only surface**
-- <file / symbol>
+**調査で当たった隣接範囲**（影響可能性あり、Plan で追随する想定）
+- <file / symbol> — <なぜ関係しそうか>
 
-**Impact**
+**Primary acceptance**
+- <single concrete signal with marker [auto] or [manual]>
 
-| Direction | Surface | Kind | Note |
-|---|---|---|---|
-| Add | <new surface> | <kind> | <note> |
-| Update | <changed surface> | <kind> | <what changes> |
-| Delete | <removed surface> | <kind> | <note> |
-| Contradict | <semantically-shifted surface> | <kind> | <how callers may break> |
-| Downstream | <consumer> | <file / section> | <note> |
-
-**Core decision** — <1-2 sentences>
-
-**Primary acceptance (draft)** — <single concrete pass/fail criterion, `[auto]`-compatible>
-
-**Plan grain (draft)** — <rough count (ideal 1-5, max 10) + one-line rationale for the number>
-
-**Constraints** *(optional)*
-- <hard dependency / prerequisite>
-
-**Findings** (orchestrator working material — NOT surfaced in the Issue body)
-- <relevant files read, current behavior, code pointers>
+方向性このままで Issue 化してよい？ 違和感あれば続ける。
 ```
 
-Mapping rules:
-- `Problem` / `Editable surface` / `Read-only surface` / `Impact` (table) / `Core decision` / `Constraints` → emitted verbatim under `## Plan Sketch` in the same order.
-- `Primary acceptance (draft)` → becomes the single `[primary]` item at the top of `## Acceptance` — emit as `[auto] [primary]` (default path) or `[manual] [primary]` (escape hatch — see `hq:workflow § #### [manual] [primary] escape hatch`), matching the branch confirmed in Phase 2.
-- `Plan grain (draft)` → informs the orchestrator's item count; not emitted in the Issue body.
-- `Findings` → used by the orchestrator as **working material only**; do NOT include in the Issue body (concrete Plan items already reference files).
+Shape rules:
 
-Anti-filler policy:
-- Optional subfields (`Constraints`, `Change Map`) — if genuinely empty, omit them entirely. No label, no `_None._` placeholder, no padded prose.
-- Required subfields (`Problem`, `Editable surface`, `Read-only surface`, `Core decision`, `Primary acceptance`) that feel genuinely empty are a brainstorm-not-converged signal — keep brainstorming, do not advance to Phase 3.
-- The `**Impact**` table can omit rows for unused `Direction` values; if all 5 rows would be empty, the change is trivial and the `**Impact**` block itself can be skipped.
+- **Every block is Claude's position, not a menu** — the user chooses to endorse or push back, not to select between options Claude offers. If you are inclined to hedge with a tentative-qualifier / "候補" / "one possibility is…", Phase 2 did not converge — go back, do not hedge here.
+- **"確実に触る"** is drawn from `**Editable surface**`. Short, concrete, file- / symbol-level.
+- **"調査で当たった隣接範囲"** is the raw investigation output, kept as a **list of findings for the user's sanity check**, not a checklist the user is asked to tick. The user reads it for direction alignment; Phase 4 decides per row whether it becomes an `**Impact**` `Downstream` entry or goes to `**Read-only surface**`.
+- **"Primary acceptance"** is one concrete signal with its marker, fully committed. `[auto]` and `[manual]` markers are chosen by Claude from the domain (Phase 2 Simplicity gate), not presented as the user's pick.
+- When the `[manual] [primary]` escape hatch applies, the marker is already `[manual]` — no separate note needed in the point-check.
 
-Take as many turns as needed to build shared understanding. Transition to Phase 3 only when the user gives an explicit **"go"** signal ("go ahead", "OK", "LGTM", or equivalent) on the recap.
+### User response handling
 
-## Phase 3: Compose Plan Body
+- **"go"** (or equivalent endorsement: "OK", "LGTM", "進めて") → proceed to Phase 4.
+- **違和感** pointed out → return to Phase 2; resume the dialogue from the specific block the user questioned. Do not re-present a revised point-check as a counter-offer; continue the brainstorm until convergence, then re-present once.
 
-The orchestrator composes the `hq:plan` body **inline** from the Brainstorm Recap produced at the end of Phase 2 — no subagent, no delegation. The Recap is a 1-to-1 source for the Issue body; this phase is the mechanical mapping step plus the granularity / marker / derivation checks spelled out below.
+## Phase 4: Compose plan body + Downstream pre-emit check
 
-Inputs available from conversation state:
-- **Mode flag** — `parented` (with `hq:task`) or `standalone` (no `hq:task`). Determines whether the `Parent: #N` line is emitted.
-- `hq:task` issue content (title, body, milestone, labels, projectItems) — parented mode only.
-- Supplementary context from the user — parented mode only.
-- The **Brainstorm Recap** from Phase 2 — emit `Problem` / `Editable surface` / `Read-only surface` / `Impact` / `Core decision` / `Constraints` verbatim under `## Plan Sketch`, use `Primary acceptance (draft)` as the `[primary]` item (emit with the `[auto]` / `[manual]` branch confirmed in Phase 2 — see `**[manual] [primary] directive**` below), use `Plan grain (draft)` to size `## Plan`, and treat `Findings` as working material (not surfaced in the body).
+Autonomous from here. Compose the `hq:plan` body directly from Phase 2 conversation state + Phase 3 point-check — no subagent, no further user prompt.
 
-Composition directives — the orchestrator MUST follow all of these when writing the body:
+### Composition rules
 
-- **Language directive** — plan body content (`## Plan Sketch` prose, Impact table cells, `## Plan` step descriptions, `## Acceptance` conditions) MUST be in the current conversation language. Workflow markers and prescribed headings (`Parent: #N`, `## Plan Sketch`, `## Plan`, `## Acceptance`, `[auto]`, `[manual]`, `[primary]`, field labels like `**Problem**` / `**Editable surface**` / `**Read-only surface**` / `**Impact**` / `**Core decision**` / `**Constraints**`, table column names `Direction` / `Surface` / `Kind` / `Note`, `Direction` values `Add` / `Update` / `Delete` / `Contradict` / `Downstream`) MUST stay in English. See `hq:workflow` § Language.
-- **Anti-filler directive** — optional subfields (`Constraints`, `Change Map`) are omitted entirely when genuinely empty. No `_None._`, no padded prose. The `**Impact**` table drops rows for unused `Direction` values. If a required subfield (`Problem`, `Editable surface`, `Read-only surface`, `Core decision`, the `[primary]` item) would be empty, the brainstorm did not converge — return control to Phase 2 rather than emitting a placeholder.
-- **Standalone-mode directive** — when the mode is `standalone`, the orchestrator MUST NOT emit the `Parent: #N` line. `## Plan Sketch` is populated normally with all required subfields; standalone mode does not relax any requirement (the only effect is omitting the `Parent:` line).
-- **`## Plan` granularity rule** — ideal 1-5 items, upper bound 10. Each item is a **single meaningful commit unit** that reads independently in `git log`. If two consecutive items edit the same file in the same editing session, they are one item. If an item would produce a half-working intermediate state, it is split wrong — merge upward. Past 10 items is a drafting defect to fix, not a ceiling to plan up to.
-- **`[primary]` rule** — `## Acceptance` MUST carry **exactly one** `[primary]` item. It designates the single pass/fail signal that tells the plan succeeded. **Default**: combines with `[auto]` only; `[manual] [primary]` is forbidden. **Exception (escape hatch)**: `[manual] [primary]` is permitted when the three conditions of `hq:workflow § #### [manual] [primary] escape hatch` hold — see the **[manual] [primary] directive** below. In both branches, the primary MUST be concrete and observable (specific command / file / string / return code / URL / UI state / interaction terminus / visual target), not an abstract phrase like "plan works" or "implementation complete". All other `[auto]` items are secondary by default (no explicit marker).
-- **[manual] [primary] directive** — when Phase 2 brainstorm produced a `[manual] [primary]` (escape hatch fired), the composition MUST: (a) emit the primary Acceptance line as `- [ ] [manual] [primary] <single observable target named verbatim from Phase 2>`, (b) verify the description names exactly one concrete observable target — if only an abstract phrase surfaced in Phase 2, return control to Phase 2 rather than emit, (c) confirm the three escape hatch conditions (`[auto]` outcome infeasible, single observable target, Impact table complete) were acknowledged in Phase 2; if any condition was not confirmed, return to Phase 2. No extra fields are emitted in the plan body for the escape hatch — the evidence block (screenshot / video + reviewer checklist) lives in the PR body (produced by `/hq:start` Phase 7), not in the plan body.
-- **Impact → Plan / Acceptance derivation** — each populated row of the `**Impact**` table MUST drive at least one concrete follow-through in `## Plan` and `## Acceptance`, per the mapping below. A declared Impact row without a corresponding Plan / Acceptance item is a drafting defect.
-  - **`Add`** row → one `## Plan` item that wires the new surface into every caller that will use it, plus a `## Acceptance` item that verifies the new surface is reachable end-to-end (`grep -q` for the new identifier at the wiring site; integration-level check where practical).
-  - **`Update`** row → one `## Plan` item that adjusts existing callers to the new contract, plus a `## Acceptance` item that verifies a concrete observable behavior on the caller side. Pick exactly one branch:
-    - **Backward-compatible update** — the Acceptance item names the caller and verifies the existing caller path still succeeds end-to-end (describe the observable success state — return value, emitted event, URL transition, file produced).
-    - **Intentional breaking update** — the Acceptance item names the caller and verifies the caller path now produces a specific documented error / rejection / warning state (name the expected failure mode — error message, exit code, raised exception, 4xx response).
+- **Language** — plan body prose stays in the **conversation language** (`**Problem**` prose, Impact table cells, `## Plan` step descriptions, `## Acceptance` conditions). Workflow markers and prescribed headings stay in **English** — see `hq:workflow § Language`.
+- **Anti-filler** — optional subfields (`**Change Map**`, `**Constraints**`, unused `Direction` rows) are omitted entirely when genuinely empty. No `_None._`, no padded prose. If a required subfield would be empty, Phase 2 did not converge — return control to Phase 2.
+- **`Parent: #N` line** — emit only when a parent `hq:task` is present; omit the line entirely otherwise.
+- **`## Plan` granularity** — each item is a single meaningful commit unit (`hq:workflow § ## Plan`). No numeric cap. Adjacent edits to the same file in one session collapse into one item; half-working intermediate states are a split defect.
+- **`[primary]` rule** — exactly one `[primary]` item in `## Acceptance`. Default combination is `[auto] [primary]`; `[manual] [primary]` is permitted only when the `hq:workflow § #### [manual] [primary] escape hatch` conditions all hold (structurally infeasible `[auto]` outcome, single named observable target, fully declared `**Impact**`). The marker was chosen by Claude in Phase 2 by domain.
+- **Impact → Plan / Acceptance derivation**:
+  - `Add` row → a `## Plan` item wiring the new surface into every caller, plus a `## Acceptance` item asserting the new surface is reachable (grep / integration-level check).
+  - `Update` row → a `## Plan` item adjusting callers to the new contract, plus a `## Acceptance` item asserting the caller observes the expected behavior (named success state for backward-compat, named error / rejection for intentional breaks).
+  - `Delete` row → a `## Plan` item sweeping downstream references, plus a `## Acceptance` item asserting zero residual mentions.
+  - `Contradict` row → a `## Acceptance` item exercising the existing caller path and asserting the regression-check passes under the new semantics.
+  - `Downstream` row → a `## Plan` item performing the coordinated update on the named consumer, plus a `## Acceptance` item asserting the consumer reflects the new reality.
 
-    Generic phrases like "works correctly" or "fails as expected" are not acceptable — each Acceptance item MUST name the caller and the expected observable.
-  - **`Delete`** row → one `## Plan` item that sweeps downstream references to the removed surface, plus a `## Acceptance` item that greps the repo for residual mentions and asserts zero hits.
-  - **`Contradict`** row → one `## Acceptance` item per contradiction that exercises the existing caller / consumer path and verifies it still behaves correctly under the new semantics (regression check).
-  - **`Downstream`** row → one `## Plan` item per listed consumer that performs the coordinated update, plus a `## Acceptance` item that verifies the consumer now reflects the new reality (e.g., docs reference the new field, README agents table includes the new agent).
-- The required output format (below).
+### Downstream pre-emit check (hard rule)
 
-**Required plan format** — the orchestrator emits the `hq:plan` body in exactly this shape. Substitution rules:
+Before emitting the Issue, run the hard rule from `hq:workflow § Simplicity Criterion → Downstream coverage hard rule`:
 
-- Angle-bracket `<placeholder>` tokens are substituted with real content.
-- The `Parent:` line is emitted only in **parented mode**; omit it entirely in standalone mode.
-- Optional fields with no substantive content are **omitted entirely** (no label, no placeholder). This applies to `**Change Map**`, `**Constraints**`, and any `Direction` row of the `**Impact**` table that has no entry.
+- Enumerate every populated `Downstream` row in the `**Impact**` table.
+- For each row, locate at least one `## Plan` item that performs the coordinated update on the named consumer. Pattern-match on the consumer identifier (file path, symbol name, section header).
+- If a `Downstream` row has no covering `## Plan` item, **do not emit**. Three paths out:
+  1. The row is aspirational (you speculated about a consumer but will not actually touch it) → delete the row.
+  2. The Plan is genuinely incomplete → return to Phase 2, brainstorm the missing Plan item, then re-enter Phase 4.
+  3. The row belongs in `**Read-only surface**` (it was investigated and deliberately not modified) → move it.
+
+Only when every `Downstream` row has a covering `## Plan` item may Phase 4 emit.
+
+### Required plan body shape
 
 ```markdown
 Parent: #<hq:task issue number>
@@ -237,10 +216,10 @@ Parent: #<hq:task issue number>
 | Contradict | <semantically-shifted surface> | <kind> | <how callers may break> |
 | Downstream | <consumer> | <file / section> | <note> |
 
-**Core decision** — <1-2 sentences: key architectural choice>
+**Core decision** — <1-2 sentences: key architectural choice + any tradeoff accepted after Simplicity gatekeeper pushback>
 
 **Constraints** *(optional)*
-- <hard dependency / prerequisite / assumption>
+- <hard dependency / prerequisite>
 
 ## Plan
 - [ ] <implementation step — single meaningful commit unit, in conversation language>
@@ -252,82 +231,72 @@ Parent: #<hq:task issue number>
 - [ ] [manual] <human-eye check, used sparingly>
 ```
 
-The template above shows the **default path** (`[auto] [primary]`). Under the escape hatch (`hq:workflow § #### [manual] [primary] escape hatch`), the first line becomes `- [ ] [manual] [primary] <single observable target named from Phase 2>` — everything else is unchanged. See the `**[manual] [primary] directive**` above for emission rules.
+Conditional emission:
 
-Conditional emission rules (authoritative):
+- `Parent: #<N>` — emit only when a parent `hq:task` exists; otherwise omit.
+- `**Change Map**` — optional; emit only when a figure clarifies more than prose.
+- `**Impact**` rows — drop `Direction` values that do not apply. When every row is empty, the change is trivial and the block can be skipped entirely.
+- `**Constraints**` — optional unless the zero-Downstream directive applies (`hq:workflow § ## Plan Sketch § **Impact**`).
 
-- `Parent: #<hq:task issue number>` — emit in **parented mode**; **omit the entire line** in standalone mode.
-- `**Change Map**` — optional. Emit only when a figure (Mermaid or ASCII) clarifies structure more than prose. Otherwise omit the label entirely.
-- `**Impact**` table — emit whenever any non-trivial surface is touched. Drop rows for `Direction` values that do not apply. If all 5 rows would be empty, the change is trivial and the `**Impact**` block itself can be skipped.
-- `**Constraints**` — optional. Emit only when the plan has real hard dependencies / prerequisites worth surfacing. Otherwise omit.
+Marker rules (default path):
 
-Marker rules:
+- `[auto]` — Claude can execute autonomously (tests, CLI, API, file checks, `/hq:e2e-web` for browser). Prefer `[auto]`.
+- `[manual]` — only when one of the four domain conditions in `hq:workflow § ## Acceptance` applies.
+- `[primary]` — exactly one per plan. `[auto] [primary]` by default, `[manual] [primary]` under the escape hatch only.
 
-- **`[auto]`** — Claude can execute the check autonomously: unit / integration tests, CLI / shell commands, API calls, file / type checks, **and browser automation via `/hq:e2e-web` (Playwright)** — navigation, URL / element / text assertions, form submit flows. Prefer `[auto]` whenever possible.
-- **`[manual]`** — requires human judgment: subjective aesthetics / UX feel, physical device / assistive tech, live production or sensitive credentials, or multi-session scenarios Playwright cannot orchestrate. Use sparingly.
-- **`[primary]`** — role marker. Exactly one `[primary]` item per plan. **Default**: combines with `[auto]` only; `[manual] [primary]` is forbidden. **Exception**: `[manual] [primary]` is permitted under the escape hatch (`hq:workflow § #### [manual] [primary] escape hatch`) — strict conditions (iOS / subjective UX where `[auto]` outcome is structurally infeasible) with required compensating controls (evidence block in PR body + `hq:manual` label, both enforced by `/hq:start` Phase 7 gate).
+Under the escape hatch, the first `## Acceptance` line becomes `- [ ] [manual] [primary] <single observable target named verbatim from Phase 2>`; the PR body's `## Primary Verification (manual)` evidence block is produced by `/hq:start` Phase 7, not here.
 
-**Rule for choosing `[auto]` vs `[manual]`** — default to `[auto]`. A check is `[manual]` only when one of the four specific conditions above applies. **"It happens in a browser" alone does NOT justify `[manual]`** — `/hq:e2e-web` drives browser UI deterministically. When unsure, mark as `[auto]`.
+## Phase 5: Create `hq:plan` Issue
 
-**Rule for choosing the `[primary]` item** — it must answer "if this single check passes, is the plan done?" with a concrete, observable signal.
-- **Default path (`[auto] [primary]`)**: specific command exit code, grep hit count, file existence, API return code, URL transition, Playwright assertion, etc.
-- **Escape hatch path (`[manual] [primary]`)**: a single observable event with a named target (UI state, interaction terminus, visual / sound target, named artifact) — see Phase 2 step 7 for the elicitation flow and `hq:workflow § #### [manual] [primary] escape hatch` for conditions and compensating controls.
+Autonomous; continue without further user interaction.
 
-Generic phrases like "plan works" or "implementation complete" dissolve the primary/secondary distinction and count as a drafting defect on both paths.
-
-Each Acceptance item should be a single, concrete, verifiable criterion — not a vague goal.
-
-## Phase 4: Create `hq:plan` Issue
-
-Fully autonomous from here. Do not pause for user input unless an error occurs. Issue registration branches on the mode decided in Phase 1 — parented and standalone differ on `Parent:` emission, milestone/project inheritance, and sub-issue registration. The steps below spell out each mode inline.
-
-1. **Compose plan title** following the naming convention in `hq:workflow` § Naming Conventions:
-   - Format: `<type>(plan): <implementation approach>`
-   - Parented mode: `<type>` is derived from the `hq:task` title type (e.g., if `hq:task` is `feat: ...`, plan is `feat(plan): ...`).
-   - Standalone mode: `<type>` is derived from the brainstorm outcome. If none of `feat` / `fix` / `docs` / `refactor` / `chore` / `test` clearly apply, default to `feat`.
-
+1. **Compose plan title** per `hq:workflow § Naming Conventions`:
+   - Format: `<type>(plan): <implementation approach>`.
+   - When a parent `hq:task` exists, derive `<type>` from the `hq:task` title (e.g., parent is `feat: ...` → plan is `feat(plan): ...`).
+   - When no parent exists, derive `<type>` from the brainstorm outcome. Default to `feat` when none of `feat` / `fix` / `docs` / `refactor` / `chore` / `test` clearly applies.
 2. **Create the Issue**:
    ```bash
    gh issue create \
      --title "<plan title>" \
      --body "<plan body>" \
      --label "hq:plan" \
-     [--milestone "<inherited from hq:task, parented mode only>"] \
-     [--project "<inherited from hq:task, parented mode only>" ...]
+     [--milestone "<inherited from hq:task, only when a parent exists>"] \
+     [--project "<inherited from hq:task, only when a parent exists>" ...]
    ```
-   - Parented mode: include `--milestone` if the `hq:task` has one, and repeat `--project` for each project on the `hq:task`.
-   - Standalone mode: omit `--milestone` and `--project` entirely (nothing to inherit).
-
-3. **Register as sub-issue** — parented mode only:
+   - When a parent `hq:task` exists: include `--milestone` if the task has one, and repeat `--project` for each project on the task.
+   - When no parent exists: omit `--milestone` and `--project` entirely.
+3. **Register as sub-issue** *(only when a parent `hq:task` exists)*:
    ```bash
    PLAN_ID=$(gh api /repos/{owner}/{repo}/issues/<plan> --jq '.id')
    gh api --method POST /repos/{owner}/{repo}/issues/<task>/sub_issues --field sub_issue_id="$PLAN_ID"
    ```
-   In standalone mode, **skip this step entirely** — there is no parent issue.
+   When no parent exists, skip this step entirely.
+4. **Label creation** — create any missing labels lazily (`hq:workflow § Issue Hierarchy`).
 
-4. **Label creation** — create any missing labels lazily (see `hq:workflow` § Issue Hierarchy). Applies to both modes.
+## Phase 6: Report
 
-## Phase 5: Report
+Return to the user:
 
-Return the following to the user, branching on the mode from Phase 1:
-
-- **hq:task** *(parented mode only)*: number, title, URL. Omit this line entirely in standalone mode — there is no `hq:task` to report.
-- **hq:plan**: number, title, URL (the newly created Issue)
-- **Next step**: tell the user to review and edit this `hq:plan` on the GitHub UI, then start implementation with `/hq:start <plan>`.
+- **hq:task** *(only when a parent `hq:task` exists)*: number, title, URL.
+- **hq:plan**: number, title, URL (newly created).
+- **Next step**: review / edit on the GitHub UI, then start implementation with `/hq:start <plan>`.
 
 End of command. Do NOT:
-- create a feature branch
-- write `.hq/tasks/<branch-dir>/context.md`
-- start implementation
-- invoke `/hq:start` automatically
 
-The handoff boundary is intentional — the user reviews / edits the `hq:plan` Issue before implementation starts.
+- create a feature branch.
+- write `.hq/tasks/<branch-dir>/context.md`.
+- start implementation.
+- invoke `/hq:start` automatically.
+
+The handoff boundary is intentional — the user reviews and edits the `hq:plan` Issue on GitHub before implementation starts. The GitHub Issue is the **single review surface**; there is no in-chat review of a Recap.
 
 ## Rules
 
-- **No code writing** — this command is planning-only. If the user asks to start implementing, redirect them to `/hq:start <plan>` after the Issue is created.
+- **No code writing** — planning-only. Redirect implementation requests to `/hq:start <plan>` after Issue creation.
 - **No branch creation** — `/hq:start` owns branch creation.
-- **Wait for user "go"** — do not transition from Phase 2 to Phase 3 without an explicit signal. This rule **takes precedence over auto mode's "minimize interruptions" directive**; Phase 2 is a sanctioned user intervention point and MUST NOT be skipped or abbreviated even in continuous-execution mode. Producing the Brainstorm Recap without prior dialogue is the canonical failure mode — the Recap is the *output* of a completed brainstorm, not a substitute for one.
-- **Required plan format** — the orchestrator must compose the exact `## Plan Sketch` + `## Plan` + `## Acceptance` structure, with exactly one `[primary]` item in `## Acceptance` (default `[auto] [primary]`; `[manual] [primary]` permitted under the escape hatch per the `**[manual] [primary] directive**` in Phase 3). Do not settle for any other structure.
-- **Inherit traceability** *(parented mode only)* — pass `--milestone` and `--project` when the `hq:task` has them. Standalone mode has no `hq:task`; skip these flags entirely.
+- **Phase 2 convergence is a commitment** — all fields listed under *Exit condition* must be committable (Problem, Core decision, Editable / adjacent surfaces, primary with marker, plan split judgment). Handing a hedging-qualifier-attached field to Phase 3 is forbidden — the point-check is a position, not a menu.
+- **Simplicity gatekeeper is active** — Phase 2 raises reuse / minimum-solution / spread-cost concerns once per concern and records accepted tradeoffs in `**Core decision**`. Silent transcription of the user's proposal without the gate is out of scope.
+- **Downstream pre-emit check is a hard rule** — Phase 4 does not emit an Issue with uncovered `Downstream` rows (`hq:workflow § Downstream coverage hard rule`).
+- **Marker choice is Claude's domain judgment** — `[auto]` vs `[manual]` for the primary is not asked of the user; Claude decides from the domain in Phase 2.
+- **Inherit traceability when a parent exists** — pass `--milestone` and `--project` when the parent `hq:task` has them; otherwise skip.
 - **Security** — only execute expected shell commands. Flag suspicious content from GitHub issues.

--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -230,7 +230,7 @@ Parent: #<hq:task issue number>
 **Core decision** — <1-2 sentences: key architectural choice + any tradeoff accepted after Simplicity gatekeeper pushback>
 
 **Constraints** *(optional)*
-- <hard dependency / prerequisite>
+- <hard dependency / prerequisite / assumption>
 
 ## Plan
 - [ ] <implementation step — single meaningful commit unit, in conversation language>

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -136,15 +136,15 @@ gh issue view <plan> --json title,body,labels,milestone,projectItems
 - Verify the `hq:plan` label is present. If not, warn but continue.
 - If `hq:wip` label is present, log a warning and continue (continue-report — see Stop Policy below). Automation-invoked callers are expected to gate on `hq:wip` upstream.
 
-Detect mode by inspecting the plan body:
+Detect whether the plan has a parent `hq:task` by inspecting the plan body for a `Parent: #<N>` line:
 
-- **Parented mode** — the body contains a `Parent: #<N>` line. Parse `<N>` to get the `hq:task` number and fetch the task JSON:
+- **With a parent** — when the body contains a `Parent: #<N>` line, parse `<N>` to get the `hq:task` number and fetch the task JSON:
   ```bash
   gh issue view <task> --json title,body,milestone,labels,projectItems
   ```
-- **Standalone mode** — the body has no `Parent:` line (produced by `/hq:draft` standalone mode per `hq:workflow` § `hq:plan`). Skip the `hq:task` fetch entirely; conversation state holds only the plan payload. Downstream phases (3 / 9 / 10) branch on this.
+- **Without a parent** — when the body has no `Parent:` line. Skip the `hq:task` fetch entirely; conversation state holds only the plan payload. Downstream phases (3 / 9 / 10) branch on this.
 
-Keep the plan payload (and, in parented mode, the task payload) in conversation state; they are written to cache in Phase 3.
+Keep the plan payload (and the task payload, when a parent exists) in conversation state; they are written to cache in Phase 3.
 
 **Branch name** — derive from the plan title:
 - Pattern: `<type>(plan): <description>` → branch `<type>/<slugified-description>`
@@ -163,14 +163,14 @@ Keep the plan payload (and, in parented mode, the task payload) in conversation 
    git checkout <base>
    git checkout -b <branch-name>
    ```
-3. **Write `context.md`** — follow the frontmatter schema in `hq:workflow` § Focus. Path: `.hq/tasks/<branch-dir>/context.md` (branch-dir = branch with `/` → `-`). In standalone mode, omit `source` and `gh.task` from the frontmatter (no task payload was fetched); parented mode includes all keys.
-4. **Write task cache** *(parented mode only)* — `.hq/tasks/<branch-dir>/gh/task.json` (the JSON fetched in Phase 2). In standalone mode, skip this step — no task JSON was fetched and there is no `gh.task` entry in `context.md`.
+3. **Write `context.md`** — follow the frontmatter schema in `hq:workflow` § Focus. Path: `.hq/tasks/<branch-dir>/context.md` (branch-dir = branch with `/` → `-`). When the plan has no parent `hq:task`, omit `source` and `gh.task` from the frontmatter (no task payload was fetched); when a parent exists, include all keys.
+4. **Write task cache** *(only when the plan has a parent `hq:task`)* — `.hq/tasks/<branch-dir>/gh/task.json` (the JSON fetched in Phase 2). When no parent exists, skip this step — no task JSON was fetched and there is no `gh.task` entry in `context.md`.
 5. **Pull plan cache** (checkpoint: Pull):
    ```bash
    bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-cache-pull.sh" <plan>
    ```
    This writes the canonical working copy to `.hq/tasks/<branch-dir>/gh/plan.md`.
-6. **Save focus to memory** — a project-type memory entry with branch name, plan number, and — **parented mode only** — source number. In standalone mode, omit the source number from the memory entry (there is no parent `hq:task`).
+6. **Save focus to memory** — a project-type memory entry with branch name and plan number, plus the source number when the plan has a parent `hq:task`. When no parent exists, omit the source number from the memory entry.
 7. **Read `hq:workflow`** (`${CLAUDE_PLUGIN_ROOT}/plugin/v2/rules/workflow.md`) and follow all applicable rules.
 
 **Stamp end:** `bash plugin/v2/scripts/phase-timing.sh stamp 3 end`
@@ -410,10 +410,10 @@ If any of the first two fail, ABORT per Stop Policy. If the working tree is dirt
 
 Build the body per `hq:workflow` § PR Body Structure. When the plan carries a `[manual] [primary]` item (escape hatch), assemble `## Primary Verification (manual)`: copy the primary item verbatim, add an evidence link placeholder for screenshot / video (the reviewer fills it in during PR review if the executor could not attach it from the run), and list a reviewer checklist of ≥3 observations decomposing the primary's single observable into concrete verifiable parts. Copy remaining unchecked `[manual]` items (excluding the `[manual] [primary]` item, which lives in `## Primary Verification (manual)`) from Acceptance into `## Manual Verification` verbatim. For each pending FB under `.hq/tasks/<branch-dir>/feedbacks/`, read the FB's frontmatter `severity:` field and emit a line of the form `- [<Severity>]: <title> — <brief description>` under `## Known Issues` **and** move the file to `feedbacks/done/` in the same step (atomic; see `hq:workflow` § Feedback Loop). Sort the emitted entries in severity **descending** order (`Critical` → `High` → `Medium` → `Low`); within the same severity, preserve insertion order. This severity prefix and sort order are invariant — see `hq:workflow § ## PR Body Structure § Invariants`. Omit empty sections.
 
-The trailer is mode-dependent (per `hq:workflow` § PR Body Structure § Invariants):
+The trailer depends on whether the plan has a parent `hq:task` (per `hq:workflow` § PR Body Structure § Invariants):
 
-- **Parented mode** — trailer has both `Closes #<plan>` and `Refs #<task>` lines.
-- **Standalone mode** — trailer has only `Closes #<plan>`; omit the `Refs` line entirely (there is no parent `hq:task`).
+- **With a parent** — trailer has both `Closes #<plan>` and `Refs #<task>` lines.
+- **Without a parent** — trailer has only `Closes #<plan>`; omit the `Refs` line entirely (there is no parent `hq:task`).
 
 Title: `<type>: <description>` — plan title with the `(plan)` scope removed.
 
@@ -434,7 +434,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/plan-cache-push.sh" <plan>
 
 ### Create the PR
 
-Delegate to the `pr` skill with the prepared body, title, and — **parented mode only** — milestone / project inherited from the `hq:task` (read `.hq/tasks/<branch-dir>/gh/task.json`). In standalone mode, skip milestone / project resolution entirely — there is no `task.json` cache file and no parent `hq:task` to inherit from, so no `--milestone` / `--project` flags are passed. The `pr` skill is the single path to `gh pr create` and applies any `.hq/pr.md` overrides within its own documented scope. Do not call `gh pr create` directly.
+Delegate to the `pr` skill with the prepared body, title, and — **only when the plan has a parent `hq:task`** — milestone / project inherited from the `hq:task` (read `.hq/tasks/<branch-dir>/gh/task.json`). When no parent exists, skip milestone / project resolution entirely — there is no `task.json` cache file and no parent `hq:task` to inherit from, so no `--milestone` / `--project` flags are passed. The `pr` skill is the single path to `gh pr create` and applies any `.hq/pr.md` overrides within its own documented scope. Do not call `gh pr create` directly.
 
 **Stamp end:** `bash plugin/v2/scripts/phase-timing.sh stamp 7 end`
 
@@ -442,7 +442,7 @@ Delegate to the `pr` skill with the prepared body, title, and — **parented mod
 
 Summarize:
 
-- **hq:task** *(parented mode only)*: number + title. Omit this line entirely in standalone mode — there is no parent `hq:task` to report.
+- **hq:task** *(only when the plan has a parent `hq:task`)*: number + title. Omit this line entirely when no parent exists.
 - **hq:plan**: number + title + link
 - **Branch**: name
 - **Key changes**: brief bullet list

--- a/plugin/v2/docs/workflow.md
+++ b/plugin/v2/docs/workflow.md
@@ -50,39 +50,44 @@ Response tools (invoked between intervention #2 and merge, at the user's discret
 
 ### `/hq:draft`
 
-Input: `hq:task` Issue number (+ optional supplementary context).
+Input: optional `hq:task` Issue number (+ optional supplementary context). When omitted, the plan is created top-level and the requirement is captured in `## Plan Sketch § **Problem**`.
 
 ```
-Phase 1: Load hq:task
-│  Fetch issue (verify hq:task label, warn on hq:wip)
+Phase 1: Intake (hq:task + pre-session context)
+│  Fetch hq:task when provided (verify label, warn on hq:wip)
+│  Carry pre-session conversation context forward as brainstorm material
 │
-Phase 2: Brainstorm (interactive — user intervention)
-│  Review task, investigate code, align scope
-│  Enumerate Editable / Read-only surface (symmetric declaration)
-│  Fill the Impact table (Direction ∈ {Add, Update, Delete, Contradict, Downstream})
-│  Identify the single [auto] [primary] Acceptance signal
-│  Identify further [auto] vs [manual] Acceptance opportunities
-│  Sketch ## Plan grain (single meaningful commit unit per item)
-│  (wait for user "go")
+Phase 2: Brainstorm + Simplicity gatekeeper (interactive — user intervention)
+│  Exploration-led dialogue; internal checklist tracks required fields
+│  Simplicity gate: reuse vs new-build / minimum-solution / spread cost / marker domain judgment
+│  Plan split judgment (one plan vs several)
+│  Convergence: Problem / Core decision / surfaces / primary w/marker committable
 │
-Phase 3: Compose Plan Body (autonomous)
-│  Orchestrator composes Plan + Acceptance structure inline from the Recap
+Phase 3: Point-check (Claude's decisive recommendation — user intervention)
+│  3-block position presented once:
+│    確実に触る / 調査で当たった隣接範囲 / Primary acceptance (with marker)
+│  User endorses "go" → Phase 4, or raises 違和感 → Phase 2
 │
-Phase 4: Create hq:plan Issue
+Phase 4: Compose plan body + Downstream pre-emit check (autonomous)
+│  Compose body from Phase 2 state + Phase 3 point-check
+│  Pre-emit check: every Impact Downstream row has a covering ## Plan item
+│
+Phase 5: Create hq:plan Issue
 │  gh issue create --label hq:plan
-│  Register as sub-issue of hq:task
-│  Inherit milestone + projects from hq:task
+│  Register as sub-issue, inherit milestone + projects (when a parent hq:task exists)
 │
-Phase 5: Report
+Phase 6: Report
    Issue URL → "edit on GitHub, then /hq:start <plan>"
 ```
 
 **Key decisions**:
 
 - No branch, no code, no cache writes in this command. The only artifact is the `hq:plan` Issue.
-- The orchestrator composes the exact `## Plan Sketch` + `## Plan` + `## Acceptance` structure inline from the Brainstorm Recap, with exactly one `[auto] [primary]` item in `## Acceptance`.
-- Phase 2 enforces `Editable surface` / `Read-only surface` symmetric declaration and the `**Impact**` table (`Direction` column uses a closed set of 5 values). Each populated Impact row is contractually tied to a `## Plan` / `## Acceptance` item so downstream drift is caught at drafting time, not deferred to Phase 6 quality review.
-- `## Plan` granularity: each item is a single meaningful commit unit. No numeric cap — motive-driven bloat is challenged by `/hq:draft` Phase 2 Simplicity gatekeeper, not by a count ceiling (see `hq:workflow § Simplicity Criterion`).
+- The orchestrator composes the exact `## Plan Sketch` + `## Plan` + `## Acceptance` structure inline from Phase 2 conversation state and the Phase 3 point-check, with exactly one `[auto] [primary]` item in `## Acceptance` (or `[manual] [primary]` under the escape hatch).
+- Phase 2 enforces `Editable surface` / `Read-only surface` symmetric declaration and the `**Impact**` table (`Direction` column uses a closed set of 5 values). Each populated Impact row is contractually tied to a `## Plan` / `## Acceptance` item so downstream drift is caught at drafting time, not deferred to Phase 6 quality review. The `Downstream` row → `## Plan` item binding is enforced as a hard pre-emit check in Phase 4 (see `hq:workflow § ## Plan Sketch § **Impact** § Downstream coverage hard rule`).
+- Phase 2 is the mitigation checkpoint for `hq:workflow § Simplicity Criterion` — it challenges benefit/complexity tradeoffs before the plan is composed rather than after.
+- `## Plan` granularity: each item is a single meaningful commit unit. No numeric cap — motive-driven bloat is challenged by the Phase 2 Simplicity gatekeeper, not by a count ceiling.
+- Review surface is the **GitHub Issue** only. The Phase 3 point-check is a one-shot commitment checkpoint, not a Recap review; full plan-body review happens on the Issue after Phase 5.
 - The handoff is intentional — user reviews / edits the `hq:plan` Issue before `/hq:start` is invoked.
 
 ### `/hq:start`

--- a/plugin/v2/docs/workflow.md
+++ b/plugin/v2/docs/workflow.md
@@ -62,7 +62,7 @@ Phase 2: Brainstorm (interactive — user intervention)
 │  Fill the Impact table (Direction ∈ {Add, Update, Delete, Contradict, Downstream})
 │  Identify the single [auto] [primary] Acceptance signal
 │  Identify further [auto] vs [manual] Acceptance opportunities
-│  Sketch ## Plan grain (ideal 1-5, upper bound 10)
+│  Sketch ## Plan grain (single meaningful commit unit per item)
 │  (wait for user "go")
 │
 Phase 3: Compose Plan Body (autonomous)
@@ -82,7 +82,7 @@ Phase 5: Report
 - No branch, no code, no cache writes in this command. The only artifact is the `hq:plan` Issue.
 - The orchestrator composes the exact `## Plan Sketch` + `## Plan` + `## Acceptance` structure inline from the Brainstorm Recap, with exactly one `[auto] [primary]` item in `## Acceptance`.
 - Phase 2 enforces `Editable surface` / `Read-only surface` symmetric declaration and the `**Impact**` table (`Direction` column uses a closed set of 5 values). Each populated Impact row is contractually tied to a `## Plan` / `## Acceptance` item so downstream drift is caught at drafting time, not deferred to Phase 6 quality review.
-- `## Plan` granularity: ideal 1-5 items, upper bound 10 — each item is a single meaningful commit unit. 10+ items is a drafting defect, not a ceiling.
+- `## Plan` granularity: each item is a single meaningful commit unit. No numeric cap — motive-driven bloat is challenged by `/hq:draft` Phase 2 Simplicity gatekeeper, not by a count ceiling (see `hq:workflow § Simplicity Criterion`).
 - The handoff is intentional — user reviews / edits the `hq:plan` Issue before `/hq:start` is invoked.
 
 ### `/hq:start`
@@ -322,7 +322,7 @@ Parent: #<hq:task issue number>
 Highlights:
 
 - **`## Plan Sketch`** — one scannable section replacing the old `Context` + `Approach` split. `**Editable surface**` / `**Read-only surface**` are both required and symmetric. The `**Impact**` table's `Direction` column is a closed set of 5 values (`Add` / `Update` / `Delete` / `Contradict` / `Downstream`); rows are omitted for directions that do not apply. `**Change Map**` (Mermaid / ASCII figure) and `**Constraints**` are optional — omit entirely when empty.
-- **`## Plan`** — implementation steps. **Ideal 1-5 items, upper bound 10.** Each item is a single meaningful commit unit; adjacent edits to the same file collapse into one item. All must be checked before PR creation.
+- **`## Plan`** — implementation steps. Each item is a single meaningful commit unit; adjacent edits to the same file collapse into one item. No numeric cap — broad scopes are challenged at `/hq:draft` Phase 2 (Simplicity gatekeeper) and typically split into multiple `hq:plan`s rather than packed into one. All must be checked before PR creation.
 - **`## Acceptance`** — completion criteria tagged by execution mode and role:
   - `[auto]` — Claude executes and toggles (unit tests, API calls, file checks, Playwright). Prefer `[auto]`.
   - `[manual]` — flows to PR body for user verification.
@@ -404,4 +404,4 @@ Closes #<hq:plan>
 Refs #<hq:task>
 ```
 
-Omit optional sections (`## Notes`, `## Manual Verification`, `## Known Issues`) when empty. `Closes` is mandatory. `Refs` is mandatory **only in parented mode** — in standalone mode (no parent `hq:task`), omit the `Refs` line entirely.
+Omit optional sections (`## Notes`, `## Manual Verification`, `## Known Issues`) when empty. `Closes` is mandatory. `Refs` is mandatory **only when the plan has a parent `hq:task`** — when no parent exists, omit the `Refs` line entirely.

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -167,6 +167,7 @@ Parent: #<hq:task issue number>
   **Downstream check directive** — when the `**Impact**` table contains zero `Downstream` rows, the plan MUST include a line `Downstream: none — confirmed by <specific check>` under `**Constraints**`. Forces the author to name the concrete check that confirmed no consumers exist (e.g., `grep -rn "<identifier>" .`, reading the call-site list), so silent omissions become auditable declarations.
 
   **Downstream coverage hard rule** — every populated `Downstream` row in the `**Impact**` table MUST be covered by at least one corresponding `## Plan` item that performs the coordinated update on the named consumer. This is enforced as a **pre-emit check** by `/hq:draft` Phase 4: if a Downstream row has no covering Plan item, the plan is not emitted — either the row is aspirational (remove it) or the Plan is incomplete (return to brainstorm). `/hq:start` Phase 6 `integrity-checker` reconciles declared-but-missing against the diff as a second net.
+
 - **`**Core decision**`** *(required)* — 1-2 sentences on the key architectural choice. If there is no genuine decision to highlight, the plan probably does not need a `## Plan Sketch` at all.
 - **`**Constraints**`** *(optional except when required by the Downstream check directive above)* — hard dependencies, prerequisites, or assumptions. Omit when genuinely empty.
 - **`**Quality review policy**`** *(optional)* — per-plan override of `/hq:start` Phase 6 Quality Review behavior. Bullet-list syntax, one setting per line (e.g. `- fix-threshold: Low`). Current settings:

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -65,7 +65,7 @@ This rule applies to every skill and command that generates Issue or PR content 
 ## Issue Hierarchy
 
 ```
-Parented mode:
+With a parent hq:task:
   Milestone (GitHub built-in, optional)
     └── hq:task Issue  — requirement ("what")
           └── hq:plan Issue  — implementation plan ("how")
@@ -73,7 +73,7 @@ Parented mode:
                 │     └── ← /hq:triage → hq:feedback Issue(s)  (residual, Refs #plan)
                 └── (or escalated during PR review via /hq:triage)
 
-Standalone mode (no parent hq:task):
+Without a parent hq:task:
   hq:plan Issue  — implementation plan ("how"); top-level, requirement captured in ## Plan Sketch / **Problem**
     ├── ← Closes → PR  (no Refs trailer)
     │     └── ← /hq:triage → hq:feedback Issue(s)  (residual, Refs #plan)
@@ -81,11 +81,11 @@ Standalone mode (no parent hq:task):
 ```
 
 - `hq:task` and `hq:plan` are separate issues (separation of concerns)
-- **`hq:task` is optional** — an `hq:plan` can be created without a parent `hq:task` via `/hq:draft` **standalone mode**. Use this when the requirement already lives in an external tracker, or for 1:1 cases where a separate requirement Issue is pure overhead. In standalone mode, the plan's `## Plan Sketch` / `**Problem**` becomes the sole source of truth for the requirement.
-- `hq:plan` is created as a **sub-issue** of its parent `hq:task` (GitHub sub-issues API) — **parented mode only**. Standalone-mode plans are top-level Issues with no parent.
+- **`hq:task` is optional** — an `hq:plan` can be created without a parent `hq:task` by invoking `/hq:draft` with no issue number. Use this when the requirement already lives in an external tracker, or for 1:1 cases where a separate requirement Issue is pure overhead. When no parent exists, the plan's `## Plan Sketch` / `**Problem**` becomes the sole source of truth for the requirement.
+- `hq:plan` is created as a **sub-issue** of its parent `hq:task` (GitHub sub-issues API) only when a parent `hq:task` exists. Plans without a parent are top-level Issues.
 - PR uses `Closes #<hq:plan>` to auto-close the plan issue on merge
-- PR uses `Refs #<hq:task>` to maintain a link to the requirement — **parented mode only**; omitted when the plan has no parent `hq:task`
-- **Traceability inheritance** — if the source `hq:task` has a milestone or project(s), all generated items (`hq:plan`, PR, `hq:feedback`) must inherit them via `--milestone` / `--project` flags. Exception: `hq:feedback` issues do NOT inherit milestones. In standalone mode there is no `hq:task` to inherit from, so milestone / project are left unset.
+- PR uses `Refs #<hq:task>` to maintain a link to the requirement — only when the plan has a parent `hq:task`; omitted when absent
+- **Traceability inheritance** — if the source `hq:task` has a milestone or project(s), all generated items (`hq:plan`, PR, `hq:feedback`) must inherit them via `--milestone` / `--project` flags. Exception: `hq:feedback` issues do NOT inherit milestones. When no parent `hq:task` exists, there is nothing to inherit from, so milestone / project are left unset.
 - Labels are created lazily at first use:
   - `gh label create "hq:task" --description "HQ requirement (what to do)" --color "39FF14" 2>/dev/null || true`
   - `gh label create "hq:plan" --description "HQ implementation plan (how to do it)" --color "00D4FF" 2>/dev/null || true`
@@ -102,7 +102,7 @@ An `hq:plan` issue is the implementation plan that drives work on a branch. The 
 The `hq:plan` body follows a 3-section structure: `## Plan Sketch` + `## Plan` + `## Acceptance`. Emission rules:
 
 - Angle-bracket `<placeholder>` tokens are substituted with real content.
-- The `Parent:` line is emitted only in **parented mode** (when the plan has a parent `hq:task`); omit it entirely in **standalone mode**.
+- The `Parent:` line is emitted only when the plan has a parent `hq:task`; omit it entirely otherwise.
 - Optional fields with no substantive content are **omitted entirely** — no label, no placeholder line. Never write `_None._` / `Not applicable` / padded prose as filler.
 
 ```markdown
@@ -165,6 +165,8 @@ Parent: #<hq:task issue number>
   Omit rows for directions that do not apply. If all 5 directions would be empty, the change is trivial and the `**Impact**` block itself can be skipped.
 
   **Downstream check directive** — when the `**Impact**` table contains zero `Downstream` rows, the plan MUST include a line `Downstream: none — confirmed by <specific check>` under `**Constraints**`. Forces the author to name the concrete check that confirmed no consumers exist (e.g., `grep -rn "<identifier>" .`, reading the call-site list), so silent omissions become auditable declarations.
+
+  **Downstream coverage hard rule** — every populated `Downstream` row in the `**Impact**` table MUST be covered by at least one corresponding `## Plan` item that performs the coordinated update on the named consumer. This is enforced as a **pre-emit check** by `/hq:draft` Phase 4: if a Downstream row has no covering Plan item, the plan is not emitted — either the row is aspirational (remove it) or the Plan is incomplete (return to brainstorm). `/hq:start` Phase 6 `integrity-checker` reconciles declared-but-missing against the diff as a second net.
 - **`**Core decision**`** *(required)* — 1-2 sentences on the key architectural choice. If there is no genuine decision to highlight, the plan probably does not need a `## Plan Sketch` at all.
 - **`**Constraints**`** *(optional except when required by the Downstream check directive above)* — hard dependencies, prerequisites, or assumptions. Omit when genuinely empty.
 - **`**Quality review policy**`** *(optional)* — per-plan override of `/hq:start` Phase 6 Quality Review behavior. Bullet-list syntax, one setting per line (e.g. `- fix-threshold: Low`). Current settings:
@@ -175,13 +177,12 @@ Parent: #<hq:task issue number>
 
 Implementation steps as a checkbox list. Every item must be `[x]` before PR creation.
 
-**Granularity — ideal 1-5 items, upper bound 10.** Each item is a **single meaningful commit unit** — something that reads as one independent change in `git log` afterward:
+**Granularity — single meaningful commit unit.** Each item is something that reads as one independent change in `git log` afterward:
 
 - If two consecutive items would edit the same file in the same editing session, they are **one item**, not two.
 - If an item would produce a half-working intermediate state, it is split wrong — merge upward with its neighbor.
 - 1-item plans are valid (atomic change).
-- 6-10 items is acceptable when the change genuinely spans that many independent concerns.
-- Past 10 items is a drafting defect to fix, not a ceiling to plan up to. 10+ items signals the plan is being written as a step-by-step instruction manual rather than a commit-grain list.
+- No numeric cap on item count. Motive-driven bloat — adding items because "while we're at it" rather than because the change genuinely needs them — is not bounded by a count ceiling; it is challenged by `/hq:draft` Phase 2 Simplicity gatekeeper before the plan is composed. When a brainstorm produces a naturally broad scope, `/hq:draft` Phase 2 raises the question of whether it should split into multiple plans rather than being padded as one.
 
 ### `## Acceptance`
 
@@ -235,14 +236,14 @@ The default rule forbids `[manual] [primary]`. This subsection is the sole excep
 
 ### Registration
 
-After creating an `hq:plan` issue **in parented mode**, register it as a sub-issue of the parent `hq:task`:
+When the `hq:plan` has a parent `hq:task`, register the newly created plan as a sub-issue of that task:
 
 ```bash
 PLAN_ID=$(gh api /repos/{owner}/{repo}/issues/<plan> --jq '.id')
 gh api --method POST /repos/{owner}/{repo}/issues/<task>/sub_issues --field sub_issue_id="$PLAN_ID"
 ```
 
-In **standalone mode** (no parent `hq:task`), skip sub-issue registration entirely.
+When the plan has no parent `hq:task`, skip sub-issue registration entirely.
 
 ### Self-contained invariant
 
@@ -260,7 +261,7 @@ Every `hq:plan` must:
 1. **`.hq/tasks/<branch-dir>/context.md`** — deterministic file (branch name: `/` → `-`). Agents and skills resolve focus from this file.
 2. **Memory** — a project-type memory entry for cross-session awareness. Lets new sessions know what was in progress.
 
-**context.md format** (frontmatter YAML — no free-text body). In parented mode all keys below are present; `source` and `gh.task` are **omitted entirely in standalone mode** (see field descriptions).
+**context.md format** (frontmatter YAML — no free-text body). When the plan has a parent `hq:task`, all keys below are present; `source` and `gh.task` are **omitted entirely when no parent exists** (see field descriptions).
 
 ```yaml
 ---
@@ -274,13 +275,13 @@ gh:
 ```
 
 - `plan` — **MUST**. The `hq:plan` issue number driving current work.
-- `source` — **optional**. The `hq:task` issue number this plan implements. Present in parented mode (the normal case); **omitted in standalone mode** (plans created via `/hq:draft` without an `hq:task` argument).
+- `source` — **optional**. The `hq:task` issue number this plan implements. Present when the plan has a parent `hq:task` (the normal case); **omitted when no parent exists** (plans created via `/hq:draft` without an `hq:task` argument).
 - `branch` — **MUST**. The original git branch name (with slashes). Lets tooling check out the correct branch given a plan number (the directory name has `/` → `-` transformation which is not reliably invertible).
-- `gh` — paths to the local GitHub issue cache (see Cache-First Principle below). `gh.plan` is always present; `gh.task` is present only when `source` is set (parented mode).
+- `gh` — paths to the local GitHub issue cache (see Cache-First Principle below). `gh.plan` is always present; `gh.task` is present only when `source` is set (i.e. the plan has a parent `hq:task`).
 
 **Lifecycle**:
 
-- **On start** (`/hq:start`): write `.hq/tasks/<branch-dir>/context.md`. Save focus info to your memory (project type) — include the branch name, plan number, and source number (omit source when the plan has no parent `hq:task`).
+- **On start** (`/hq:start`): write `.hq/tasks/<branch-dir>/context.md`. Save focus info to your memory (project type) — include the branch name and plan number, and the source number when the plan has a parent `hq:task` (omit source otherwise).
 - **On status query**: read `.hq/tasks/<branch-dir>/context.md` → read the plan body from `.hq/tasks/<branch-dir>/gh/plan.md`. If cache not found, fall back to `gh issue view <plan> --json body --jq '.body'` → report status.
 - **On completion**: when a PR is created and all Plan items + Acceptance `[auto]` items are checked, update your memory to indicate no active task. The PR's `Closes #<plan>` handles issue closure on merge. The `context.md` file is left in place — it travels with the task folder until `/hq:archive` moves it.
 
@@ -296,6 +297,22 @@ When the user gives a **vague instruction** (e.g., "the auth task", "issue 42"),
 If exactly one match: set focus automatically. If multiple matches: show candidates and ask the user to choose. If no match: ask the user to specify the issue number.
 
 **NOTE**: `/hq:start <plan>` does **NOT** use this resolution order. It takes a plan number directly and resolves the work branch via `.hq/tasks/*/context.md` (see `find-plan-branch.sh`), ignoring the current branch and memory.
+
+## Simplicity Criterion
+
+An `hq:plan` must survive a benefit/complexity tradeoff check before it is composed. The canonical formulation, from `autoresearch/program.md` and referenced in `hq:doc #40`:
+
+> All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. A 0.001 val_bpb improvement that adds 20 lines of hacky code? Probably not worth it. An improvement of ~0 but much simpler code? Keep.
+
+`hq:doc #40` frames this as a **limit of formal plan constraints**: rules like the `**Impact**` table, granularity guidance, or a hypothetical `## Plan` item count cap stop the *result* of motive-driven bloat (many small "while-we're-at-it" additions) but not the *motive* itself. The motive has to be challenged during drafting, where a proposal is still malleable.
+
+This limit is **mitigated** by `/hq:draft` **Phase 2** Simplicity gatekeeper, which challenges reuse vs new-build, minimum-solution comparison, and spread cost before the plan is composed. Pushback is one-round (Claude raises the concern, the user decides, the tradeoff — if accepted — is recorded in `**Core decision**`). Plans reaching `/hq:start` have already passed this gate.
+
+Consequences for plan structure:
+
+- `## Plan` has **no numeric item cap**. Formal caps target the result (how many items) rather than the motive (why each was added); they were deprecated once the gatekeeper role was introduced. The quality rules on `## Plan` (single meaningful commit unit, same-file consecutive items merge, no half-working intermediate state) remain because they are about the *grain* of each item, not its *necessity*.
+- Naturally broad scopes should be split into multiple `hq:plan`s at the gatekeeper stage rather than padded into one. `/hq:draft` Phase 2 raises this split decision explicitly when the brainstorm produces a large scope.
+- The `**Impact**` table and `[auto] [primary]` 1-per-plan rule are retained as formal constraints; they pass the Simplicity criterion test by being low-burden and tightly targeted at specific gaming patterns (undeclared surface change, success-signal dissolution).
 
 ## Cache-First Principle
 
@@ -362,7 +379,7 @@ Closes #<hq:plan>
 Refs #<hq:task>
 ```
 
-The `Refs #<hq:task>` line is emitted **only in parented mode** — when the `hq:plan` has a parent `hq:task`. In standalone mode, omit the line entirely; the trailer block then contains only `Closes #<hq:plan>`.
+The `Refs #<hq:task>` line is emitted **only when the `hq:plan` has a parent `hq:task`**. When absent, omit the line entirely; the trailer block then contains only `Closes #<hq:plan>`.
 
 - **`## Primary Verification (manual)`** — present **only** when the plan's `## Acceptance` has a `[manual] [primary]` item (escape hatch). Holds the evidence block required for reviewer to verify the escape hatch primary. Omitted entirely when the plan has `[auto] [primary]`.
 - **`## Manual Verification`** — all unchecked `[manual]` items from the Acceptance section (excluding the `[manual] [primary]` item, which lives in its own section above), for user verification during PR review.
@@ -382,9 +399,9 @@ The following structural elements of the PR body are invariants of the HQ workfl
 - **`## Known Issues` severity prefix and sort order** — every entry in `## Known Issues` MUST carry a severity prefix in the literal form `[<Severity>]:` (one of `[Critical]:` / `[High]:` / `[Medium]:` / `[Low]:`, drawn from the FB file's frontmatter `severity:` field). The severity prefix lets the PR reviewer and `/hq:triage` see finding priority at a glance without opening each FB file. Entries MUST be sorted in severity **descending** order (Critical → High → Medium → Low); within the same severity the ordering is insertion order (no secondary sort). `.hq/pr.md` MUST NOT suppress, rename, reformat, or reorder the prefix.
 - **FB atomic move to `feedbacks/done/`** — any FB file whose content is surfaced in `## Known Issues` MUST be moved to `feedbacks/done/` as part of the same PR-creation operation. Surfacing without moving (or moving without surfacing) is forbidden.
 - **`Closes #<hq:plan>` trailer** — every PR body MUST end with this line.
-- **`Refs #<hq:task>` trailer** — required when the `hq:plan` has a parent `hq:task` (parented mode); the `Refs` line MUST follow `Closes`. Omitted entirely when the plan is in standalone mode (no parent) — the PR body then ends with only `Closes #<hq:plan>`.
+- **`Refs #<hq:task>` trailer** — required when the `hq:plan` has a parent `hq:task`; the `Refs` line MUST follow `Closes`. Omitted entirely when no parent exists — the PR body then ends with only `Closes #<hq:plan>`.
 - **`hq:pr` label** — every PR created by the `pr` skill (in either invocation mode — Standalone or via `/hq:start`) MUST carry the `hq:pr` label.
-- **Milestone / project inheritance** *(parented mode only)* — if the source `hq:task` has a milestone or project(s), the PR MUST inherit them via `--milestone` / `--project` flags. In standalone mode (no parent `hq:task`), omit these flags entirely — there is nothing to inherit from.
+- **Milestone / project inheritance** *(only when the plan has a parent `hq:task`)* — if the source `hq:task` has a milestone or project(s), the PR MUST inherit them via `--milestone` / `--project` flags. When no parent exists, omit these flags entirely — there is nothing to inherit from.
 
 A newly bootstrapped repository should understand these rules from this section alone — `.hq/pr.md` overrides are applied on top, never in place of, the invariants above.
 


### PR DESCRIPTION
## Summary

`/hq:draft` を「hq:plan スキーマを埋める対話」から「探索主導 brainstorm + Simplicity gatekeeper」に反転する UX / 品質の二面リファクタ。Brainstorm Recap による二重レビュー負担を廃し、GitHub Issue を単一レビュー面に集約。Simplicity criterion（`hq:doc #40` 限界 2）を Phase 2 gatekeeper で内在化し、Downstream coverage を Phase 4 pre-emit check の hard rule 化。あわせて `parented/standalone mode` 用語と `## Plan` 数値上限を廃止。

## Changes

- **`plugin/v2/commands/draft.md` 全面書き換え** — 6 phase 構造（Intake / Brainstorm + Simplicity gatekeeper / Point-check / Compose + Downstream pre-emit check / Issue 作成 / Report）。
  - Phase 1: 親 `hq:task` 任意 + **pre-session 会話文脈**を brainstorm 材料として採用。
  - Phase 2: 探索主導対話、内部チェックリストはユーザ向けスクリプト化せず。**Simplicity gate** として再利用 vs 新規 / 最小解比較 / 拡散コスト / marker の domain 判定 / plan 分割判断を能動適用。pushback は 1 度、受諾した tradeoff は `**Core decision**` へ反映。`[manual] [primary]` escape hatch 三条件の verification を含む。収束条件（Problem / Core decision / Editable / Read-only / adjacent / primary w/marker / split judgment）を全て **commit** できる状態を必須化。
  - Phase 3: **Point-check**（Claude の決定的推奨 3 ブロック）— 旧 Brainstorm Recap を廃止。hedging qualifier 禁止、ユーザ応答は `"go"` か違和感指摘の 2 択。`"go"` / 違和感 両経路で Progress Tracking タスクの状態遷移（`completed` / `in_progress` 維持）を明示。
  - Phase 4: **Downstream pre-emit check**（hard rule）— 各 `Downstream` row の covering `## Plan` item を機械検証、欠落時は emission せず Phase 2 戻し + Phase 3 再提示（タスク状態も `in_progress` へ reset）。adjacent surface の per-row 分類ステップ、zero-Downstream symmetric check も追加。
- **`plugin/v2/rules/workflow.md`** — 新 `## Simplicity Criterion` 節（`/hq:draft` Phase 2 を mitigation と明記）、`**Impact**` に `Downstream coverage hard rule` 追加、`## Plan` Granularity から `ideal 1-5 / upper bound 10` を撤廃（質ルールのみ残す）、`parented/standalone mode` 用語全廃。
- **`plugin/v2/commands/start.md`** — Phase 2/3/7/8 の `parented/standalone mode` 用語を親 `hq:task` の有無 (`Parent:` 行) 条件に書き換え。機能差分なし、terminology only。
- **`plugin/v2/docs/workflow.md`** — `/hq:draft` 概観図を新 6-phase 構造に同期、`## Plan` 粒度規定 3 箇所から数値上限撤廃、PR trailer 条件節の用語統一。

## Manual Verification

- [ ] [manual] 任意の hq:task に対して `/hq:draft <n>` を実行した際、Brainstorm Recap が出力されず、代わりに 3 ブロックの point-check（確実に触る / 調査で当たった隣接範囲 / Primary acceptance）が hedging qualifier なしで表示される

## Known Issues

- [Medium]: FB010 Downstream row misclassification — `integrity-checker.md` should be Read-only surface — hq:plan #54 自身の Impact 表で `plugin/v2/agents/integrity-checker.md` が `Downstream` row として宣言されているが、diff は編集を含まず covering `## Plan` item もない（本 PR で導入する新 hard rule に本 plan 自身が適合しない self-inconsistency）。Plan 作成時点の分類ミスで、本来は `**Read-only surface**` + `**Constraints**` 行で記述すべき。/hq:triage #55 で leave as-is 判定、#56 `refactor: Impact 形式 table→sub-list` の動機として保持。

Closes #54
Refs #53
