### PR TITLE
feat: extend Project Overrides convention to draft/start/triage/respond

### DIFF
--- a/plugin/v2/commands/draft.md
+++ b/plugin/v2/commands/draft.md
@@ -50,6 +50,9 @@ Set each to `in_progress` when starting and `completed` when done.
 
 - Branch: !`git branch --show-current 2>/dev/null || echo "(detached)"`
 - Focus: !`bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/read-context.sh"`
+- Project Overrides (`.hq/draft.md`): !`cat .hq/draft.md 2>/dev/null || echo "none"`
+
+If `Project Overrides` is not `none`, apply the content as project-specific guidance layered on top of this command's phases and gates. Overrides augment — they cannot replace the phase structure, the Phase 2 Simplicity gate, the Phase 3 point-check contract, or the Downstream pre-emit check. See `hq:workflow § Project Overrides` for the canonical convention.
 
 **`hq:workflow`** — shorthand for `${CLAUDE_PLUGIN_ROOT}/plugin/v2/rules/workflow.md` (plugin-internal source of truth). Read it with the Read tool when this command starts so all subsequent phases have the rule available. All `hq:workflow § <name>` citations below refer to sections of that file.
 

--- a/plugin/v2/commands/respond.md
+++ b/plugin/v2/commands/respond.md
@@ -34,6 +34,9 @@ Set each to `in_progress` when starting and `completed` when done. Update the su
 - PR: !`gh pr view --json number,url,title,state --jq '"#" + (.number|tostring) + " " + .title + " (" + .state + ") " + .url' 2>/dev/null || echo "none"`
 - Repo: !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "unknown"`
 - Git user: !`git config user.name`
+- Project Overrides (`.hq/respond.md`): !`cat .hq/respond.md 2>/dev/null || echo "none"`
+
+If `Project Overrides` is not `none`, apply the content as project-specific guidance layered on top of this command's phases. Overrides augment — they cannot replace the three-category classification (Fix / Feedback / Dismiss), the regression gate, or the evidence-based reply rule. See `hq:workflow § Project Overrides` for the canonical convention.
 
 ## Phase 1: Preconditions
 

--- a/plugin/v2/commands/start.md
+++ b/plugin/v2/commands/start.md
@@ -37,6 +37,9 @@ Set each to `in_progress` when starting and `completed` when done. If a phase is
 
 - Branch: !`git branch --show-current 2>/dev/null || echo "(detached)"`
 - Focus: !`bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/read-context.sh"`
+- Project Overrides (`.hq/start.md`): !`cat .hq/start.md 2>/dev/null || echo "none"`
+
+If `Project Overrides` is not `none`, apply the content as project-specific guidance layered on top of this command's phases and gates. Overrides augment — they cannot replace the phase structure, the Commit Policy, the Phase 5 sweep contract, the Phase 6 Quality Review agent matrix, or the Phase 7 PR creation gate. See `hq:workflow § Project Overrides` for the canonical convention.
 
 **`hq:workflow`** — shorthand for `${CLAUDE_PLUGIN_ROOT}/plugin/v2/rules/workflow.md` (plugin-internal source of truth). Canonical definition in `hq:workflow § Terminology`. All `hq:workflow § <name>` citations below refer to sections of that file. Read it with the Read tool when this command starts (Phase 1) so all subsequent phases have the rule available.
 

--- a/plugin/v2/commands/triage.md
+++ b/plugin/v2/commands/triage.md
@@ -36,6 +36,9 @@ Set each to `in_progress` when starting and `completed` when done. Update the "T
 
 - Branch: !`git branch --show-current 2>/dev/null || echo "(detached)"`
 - Focus: !`bash "${CLAUDE_PLUGIN_ROOT}/plugin/v2/scripts/read-context.sh"`
+- Project Overrides (`.hq/triage.md`): !`cat .hq/triage.md 2>/dev/null || echo "none"`
+
+If `Project Overrides` is not `none`, apply the content as project-specific guidance layered on top of this command's phases. Overrides augment — they cannot replace the three-disposition triage contract (add to `hq:plan` / leave / escalate to `hq:feedback`) or the atomic PR body edit rule. See `hq:workflow § Project Overrides` for the canonical convention.
 
 ## Phase 1: Load PR
 

--- a/plugin/v2/docs/workflow.md
+++ b/plugin/v2/docs/workflow.md
@@ -413,3 +413,11 @@ Refs #<hq:task>
 ```
 
 Omit optional sections (`## Notes`, `## Manual Verification`, `## Known Issues`) when empty. `Closes` is mandatory. `Refs` is mandatory **only when the plan has a parent `hq:task`** — when no parent exists, omit the `Refs` line entirely.
+
+### Project Overrides
+
+Every hq command / skill / agent may consult a project-local override file under `.hq/` (e.g. `.hq/draft.md`, `.hq/start.md`, `.hq/triage.md`, `.hq/respond.md`, `.hq/pr.md`, `.hq/code-review.md`, `.hq/security-scan.md`, `.hq/integrity-check.md`, `.hq/xcodebuild-config.md`). Override content is free-form guidance that augments the consumer's default behavior; it cannot replace phases, gates, or other Invariants the consumer defines for itself.
+
+`.hq/` is gitignored by `hq:bootstrap` Task 4, so overrides are per-clone by default. Teams that want shared policy either un-ignore specific files and commit them, or upstream the policy into `plugin/v2/rules/workflow.md`. The latter is the canonical path.
+
+See `hq:workflow § Project Overrides` for the authoritative table of override files, scope rules, and worktree propagation behavior.

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -32,6 +32,37 @@
 
 These are plugin-specific terms. Always use the `hq:` prefix to distinguish from general "task", "plan", or "feedback".
 
+## Project Overrides
+
+Every hq command, skill, and agent MAY consult a project-local override file under `.hq/` and layer its content on top of the defaults defined in this rule file. Overrides **augment**, never **replace**, the workflow contract — a consumer's own Invariants (phases, gates, required outputs, structural invariants of generated artifacts such as the PR body) remain in force.
+
+### Override files
+
+| Override file | Consumed by | Typical content |
+|---|---|---|
+| `.hq/draft.md` | `/hq:draft` | Domain-specific acceptance defaults (e.g. always prefer `[manual]` primary on iOS / CLI / instruction-only projects), brainstorm hints, plan-split preferences |
+| `.hq/start.md` | `/hq:start` | Project-specific execution nuance (commit / build / test notes that the command's phases should layer in) |
+| `.hq/triage.md` | `/hq:triage` | Default disposition guidance per Known-Issue category |
+| `.hq/respond.md` | `/hq:respond` | Reply tone / language, project-specific dismissal criteria |
+| `.hq/pr.md` | `pr` skill | PR body prose style, title conventions — scope-limited by the `pr` skill's own Invariants |
+| `.hq/code-review.md` | `code-reviewer` agent | Project-specific review axes |
+| `.hq/security-scan.md` | `security-scanner` agent | Project-specific security patterns |
+| `.hq/integrity-check.md` | `integrity-checker` agent | Project-specific plan / diff reconciliation hints |
+| `.hq/xcodebuild-config.md` | `xcodebuild-config` skill | Xcode build / run commands — managed by the skill itself (not hand-authored) |
+
+Override files are optional. Absence means "apply defaults"; missing files are never errors. Each consumer resolves its override file by a literal `cat .hq/<name>.md` (or equivalent Read) at load time.
+
+### Scope rules
+
+- **Overrides augment, Invariants govern.** A consumer's Invariants are NOT overridable. If override content appears to contradict an Invariant, the Invariant wins; the consumer SHOULD flag the conflict to the user after execution so the override file can be corrected.
+- **Local to the consuming command / skill / agent.** An override file affects only its own consumer. It cannot introduce new phases, gates, or mandatory checks that alter another command's behavior. Cross-command behavior changes go through this rule file, not through overrides.
+- **Per-clone by default.** `.hq/` is included in `.gitignore` by `hq:bootstrap` Task 4, so override files are **per-clone / per-worktree** and NOT team-shared out of the box. Teams that want shared policy either (a) un-ignore specific override files and commit them, or (b) upstream the policy into this rule file. The former is experimental and risks per-member drift; the latter is the canonical path for team-wide rules.
+- **Worktree propagation.** `plugin/v2/skills/worktree-setup/scripts/worktree-setup.sh` copies existing override files into a newly created worktree so the worktree inherits the same behavior without re-setup. New override file names introduced here MUST be added to that script's copy list.
+
+### Language
+
+Override content is free-form prose in the project's working language (typically the user's conversation language). No structural markers are required — the consumer reads the file body as guidance.
+
 ## Naming Conventions
 
 Titles follow **Conventional Commits** style. Recognized `<type>` values: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`.

--- a/plugin/v2/skills/worktree-setup/scripts/worktree-setup.sh
+++ b/plugin/v2/skills/worktree-setup/scripts/worktree-setup.sh
@@ -149,8 +149,8 @@ if [[ -d "$source_dir/.claude/rules" ]]; then
   copied_files+=(".claude/rules/")
 fi
 
-# .hq/ project override files
-for hq_override in pr.md code-review.md xcodebuild-config.md; do
+# .hq/ project override files (keep in sync with plugin/v2/rules/workflow.md § Project Overrides)
+for hq_override in draft.md start.md triage.md respond.md pr.md code-review.md security-scan.md integrity-check.md xcodebuild-config.md; do
   if [[ -f "$source_dir/.hq/$hq_override" ]]; then
     mkdir -p "$worktree_dir/.hq"
     cp "$source_dir/.hq/$hq_override" "$worktree_dir/.hq/$hq_override"


### PR DESCRIPTION
## Summary

`plugin/v2/rules/workflow.md` に `## Project Overrides` 節を authoritative として新設し、既存の `.hq/<name>.md` override 規約（これまで `pr` skill / `code-reviewer` / `security-scanner` / `integrity-checker` / `xcodebuild-config` が個別に参照していた）を一覧化した。その上で `/hq:draft` / `/hq:start` / `/hq:triage` / `/hq:respond` の 4 コマンドにも同規約を適用し、各コマンド実行時に `.hq/<cmd>.md` を読み込んで project-specific guidance として layer するフローにした。

iOS / CLI / instruction-only など `[auto]` acceptance が成立しにくいプロジェクトで、毎回 `/hq:draft` で `[manual]` 方針を交渉する必要がなくなる — `.hq/draft.md` に 1 度書けば以降それがデフォルト方針になる。

## Changes

- `plugin/v2/rules/workflow.md` — `## Project Overrides` 節を新設（9 ファイルの一覧表、scope rules、Language 規約、worktree propagation 規約）
- `plugin/v2/docs/workflow.md` — Shared Concepts 末尾に Project Overrides サブセクションを追加（rules 側への pointer）
- `plugin/v2/commands/{draft,start,triage,respond}.md` — `## Context` ブロックに `Project Overrides (.hq/<cmd>.md)` 行 + 各コマンドの Invariants を上書きできない旨の注記
- `plugin/v2/skills/worktree-setup/scripts/worktree-setup.sh` — override ファイルのコピー対象リストを 9 本に拡張（従来 `pr.md` / `code-review.md` / `xcodebuild-config.md` のみ → `draft.md` / `start.md` / `triage.md` / `respond.md` / `security-scan.md` / `integrity-check.md` を追加）

## Notes

### 個人設定スコープ

`.hq/` は `hq:bootstrap` Task 4 で `.gitignore` に入っているため、override ファイルは **per-clone / 個人設定** として運用される（team-shared ではない）。実験段階での個人差を許容する意図的な設計判断。team-wide に昇格したくなったら rules/workflow.md 本体に upstream するのが canonical path — その旨を `## Project Overrides § Scope rules` に明記してある。

### worktree-setup の非冪等性 — follow-up #62

`worktree-setup.sh` は既存 worktree ディレクトリを検出すると pre-flight で `exit 1` するため冪等ではない。よって **この PR のマージ以前に作成された worktree には新 override ファイル群が自動では伝播しない**。既存 worktree で新 override を活かしたい場合は手動で `cp` するか、もしくは follow-up Issue #62 の `/hq:worktree-sync` skill の実装を待つ。新規 worktree では規約通り伝播する。

### 未変更

既存の project override 参照（`pr` skill の elaborate Override scope / Invariants セクション、各 agent の Load Criteria 内 references）は canonical な定義とは独立して機能しているため触っていない。今回 authoritative な `## Project Overrides` 節が rules/workflow.md に出来たので、将来それらを薄くして rules 側への参照に寄せることは可能だが、本 PR のスコープ外。