### PR TITLE
refactor: /hq:triage Phase 3 を strict-interactive + advisory suggestion 化

### DIFF
--- a/plugin/v2/commands/triage.md
+++ b/plugin/v2/commands/triage.md
@@ -80,7 +80,7 @@ For each item, emit **all three** of the following before waiting for the user's
 
 - **概要** (Summary, 2-3 sentences) — plain-language description of what the FB is pointing out. Translate technical shorthand into something the reviewer can act on in seconds.
 - **浮上経緯** (Origin) — which agent / which review axis surfaced this item, drawn from the `[<originating-agent>]` tag in the PR body line.
-- **Suggestion** — one of `(1)` / `(2)` / `(3)` with a 1-2 sentence rationale tying the suggestion to the FB's actual content. Bias toward `(2) leave as-is` when the call is genuinely ambiguous (documentation-only nits, false-positive-shaped findings, low-impact stylistic notes). Use `(3) escalate to hq:feedback` only when the item names a clearly different owner or operates on a clearly different timescale than the current PR. The historical failure mode is too many `(1)` / `(3)` dispositions polluting the issue tracker with "while-we're-at-it" carve-outs.
+- **Suggestion** — one of `1` / `2` / `3` with a 1-2 sentence rationale tying the suggestion to the FB's actual content. Bias toward `2` (leave as-is) when the call is genuinely ambiguous (documentation-only nits, false-positive-shaped findings, low-impact stylistic notes). Use `3` (escalate to hq:feedback) only when the item names a clearly different owner or operates on a clearly different timescale than the current PR. The historical failure mode is too many `1` / `3` dispositions polluting the issue tracker with "while-we're-at-it" carve-outs.
 
 Briefing template (the literal shape to emit per item):
 
@@ -89,12 +89,12 @@ Item <n>/<total> [<category>]: <item text>
 
   概要: <2-3 sentences of plain-language summary>
   浮上経緯: <originating agent / review axis>
-  Suggestion: (<1|2|3>) <add to hq:plan | leave as-is | escalate to hq:feedback> — <1-2 sentence rationale>
+  Suggestion: <1|2|3> (<add to hq:plan | leave as-is | escalate to hq:feedback>) — <1-2 sentence rationale>
 
-Choose disposition for this item:
-  (1) add to hq:plan (follow-up work)
-  (2) leave as-is
-  (3) escalate to hq:feedback (carve out as separate Issue)
+Choose disposition for this item — reply with 1, 2, or 3:
+  1 — add to hq:plan (follow-up work)
+  2 — leave as-is
+  3 — escalate to hq:feedback (carve out as separate Issue)
 ?
 ```
 

--- a/plugin/v2/commands/triage.md
+++ b/plugin/v2/commands/triage.md
@@ -70,27 +70,58 @@ If the section is empty or absent, report "No Known Issues to triage." and end.
 
 List the items for the user, numbered **and grouped by category** so the action priority is obvious — Must Address first, then Recommended, then Optional. Within each category, preserve insertion order from the PR body.
 
-## Phase 3: Triage Items (interactive)
+## Phase 3: Triage Items (strict-interactive)
 
-For each item, ask the user:
+Process items **one at a time**, strictly serially: present item n → wait for the user's explicit response → record → only then present item n+1. Do NOT present multiple items in a single prompt, do NOT collect "bulk" decisions, and do NOT advance on silent / ambiguous / blanket responses. The per-item briefing is the load-bearing surface that keeps each disposition grounded in the FB's actual content rather than a categorical pre-decision; surrendering that anchor (e.g., asking "what should we do for all 5 items?", or accepting "go with your suggestion") restores the autonomous-suggestion failure mode this design exists to block.
+
+### Per-item briefing (required for every item)
+
+For each item, emit **all three** of the following before waiting for the user's response. The Suggestion is advisory only — it is the agent's read of the finding, NOT a vote, default, or pre-applied disposition; the user's explicit response is the sole authority for what gets applied.
+
+- **概要** (Summary, 2-3 sentences) — plain-language description of what the FB is pointing out. Translate technical shorthand into something the reviewer can act on in seconds.
+- **浮上経緯** (Origin) — which agent / which review axis surfaced this item, drawn from the `[<originating-agent>]` tag in the PR body line.
+- **Suggestion** — one of `(1)` / `(2)` / `(3)` with a 1-2 sentence rationale tying the suggestion to the FB's actual content. Bias toward `(2) leave as-is` when the call is genuinely ambiguous (documentation-only nits, false-positive-shaped findings, low-impact stylistic notes). Use `(3) escalate to hq:feedback` only when the item names a clearly different owner or operates on a clearly different timescale than the current PR. The historical failure mode is too many `(1)` / `(3)` dispositions polluting the issue tracker with "while-we're-at-it" carve-outs.
+
+Briefing template (the literal shape to emit per item):
 
 ```
 Item <n>/<total> [<category>]: <item text>
+
+  概要: <2-3 sentences of plain-language summary>
+  浮上経緯: <originating agent / review axis>
+  Suggestion: (<1|2|3>) <add to hq:plan | leave as-is | escalate to hq:feedback> — <1-2 sentence rationale>
+
+Choose disposition for this item:
   (1) add to hq:plan (follow-up work)
   (2) leave as-is
   (3) escalate to hq:feedback (carve out as separate Issue)
 ?
 ```
 
-`<category>` reflects the PR body's grouping — `Must Address` / `Recommended` / `Optional`. Default disposition leanings (the user is free to override per item):
+### Accepted responses
 
-- **Must Address (Critical / High)** — strong lean toward `(1) add to hq:plan` or `(3) escalate to hq:feedback`. Leaving Critical / High as-is requires explicit user judgment ("this is acknowledged as a known limitation").
-- **Recommended (Medium)** — genuine judgment call. All three dispositions are routinely appropriate; user decides per item.
-- **Optional (Low)** — strong lean toward `(2) leave as-is` or `(3) escalate to hq:feedback`. Pulling Low items into `hq:plan` follow-up work risks the same scope creep that motivated the Phase 7 pure-review design.
+The user response MUST be **exactly one** of the literal strings `1`, `2`, or `3` (surrounding whitespace tolerated). Anything else is rejected:
 
-Record the user's choice per item. Allow the user to skim-then-decide: if they ask to see all items first, show the full list and revisit decisions in order.
+- silent / blank / no response → halt
+- `y` / `yes` / `ok` / "👍" / "go with your suggestion" / "your call" → halt
+- "全部 (2) で" / "bulk leave" / "leave all" / multiple numbers like `1, 2` / range like `1-3` → halt
+- free-form natural-language disposition ("add it to the plan", "escalate that one") → halt
 
-**Do not apply any changes yet** — collect all decisions first, then apply in Phase 4.
+On halt, re-emit the same item's full briefing verbatim and re-prompt. Do NOT fall back to the Suggestion. Do NOT advance to item n+1. Do NOT silently re-classify a free-form answer into a numeric disposition. The agent's job on rejection is to ask the same question again, not to interpret intent.
+
+### Serialization (one at a time)
+
+Items are processed strictly one at a time:
+
+1. Present item n's briefing (with Summary / Origin / Suggestion).
+2. Wait for the user's response.
+3. Validate per "Accepted responses". On halt, re-prompt with the same briefing.
+4. On a valid response, record the disposition for item n.
+5. Then — only then — present item n+1.
+
+Skim mode is **read-only**. The user MAY ask to see the full list of items before disposing of any; in that case emit a numbered read-only summary (no briefing, no Suggestion) and immediately return to the strict one-at-a-time loop for the actual disposition decisions. Skim presentation never collects dispositions.
+
+**Do not apply any changes yet** — Phase 4 applies the recorded dispositions atomically.
 
 ## Phase 4: Apply Changes
 
@@ -159,7 +190,8 @@ Summarize:
 ## Rules
 
 - **Only this command creates `hq:feedback` Issues** — all other workflow commands route residual problems through the PR body.
-- **Interactive for the triage phase only** — Phase 3 requires user decisions, but Phase 4 applies them autonomously.
+- **No disposition may be APPLIED without an explicit per-item response from the user.** Suggestions are advisory only; absence of an explicit response means halt, never default-to-suggestion. This invariant is the structural barrier that keeps the agent's read of a finding (the Suggestion) cleanly separated from the user's authoritative disposition decision; collapsing the two — by accepting "go with your suggestion" / bulk responses / silent acquiescence — restores the autonomous Issue-tracker pollution this command's Phase 3 is designed to block.
+- **Interactive for the triage phase only** — Phase 3 requires explicit per-item user decisions, but Phase 4 applies the recorded dispositions autonomously.
 - **Atomic PR body update** — apply all per-item edits in a single `gh pr edit` call, not one call per item.
 - **Cache sync for `hq:plan` additions** — go through `plan-cache-pull.sh` and `plan-cache-push.sh`. Do NOT `gh issue edit` the plan directly.
 - **Preserve unrelated PR body content** — only modify the `## Known Issues` section.

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -44,7 +44,7 @@ Every hq command, skill, and agent MAY consult a project-local override file und
 |---|---|---|
 | `.hq/draft.md` | `/hq:draft` | Domain-specific acceptance defaults (e.g. always prefer `[manual]` primary on iOS / CLI / instruction-only projects), brainstorm hints, plan-split preferences |
 | `.hq/start.md` | `/hq:start` | Project-specific execution nuance (commit / build / test notes that the command's phases should layer in) |
-| `.hq/triage.md` | `/hq:triage` | Default disposition guidance per Known-Issue category |
+| `.hq/triage.md` | `/hq:triage` | Briefing tone / Suggestion wording hints / project-specific lean cues for individual findings. MUST NOT contain category-level or severity-level disposition pre-decisions — the command's Phase 3 invariant forbids applying any disposition without an explicit per-item user response. |
 | `.hq/respond.md` | `/hq:respond` | Reply tone / language, project-specific dismissal criteria |
 | `.hq/pr.md` | `pr` skill | PR body prose style, title conventions — scope-limited by the `pr` skill's own Invariants |
 | `.hq/code-review.md` | `code-reviewer` agent | Project-specific review axes |

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -44,7 +44,7 @@ Every hq command, skill, and agent MAY consult a project-local override file und
 |---|---|---|
 | `.hq/draft.md` | `/hq:draft` | Domain-specific acceptance defaults (e.g. always prefer `[manual]` primary on iOS / CLI / instruction-only projects), brainstorm hints, plan-split preferences |
 | `.hq/start.md` | `/hq:start` | Project-specific execution nuance (commit / build / test notes that the command's phases should layer in) |
-| `.hq/triage.md` | `/hq:triage` | Briefing tone / Suggestion wording hints / project-specific lean cues for individual findings. MUST NOT contain category-level or severity-level disposition pre-decisions — the command's Phase 3 invariant forbids applying any disposition without an explicit per-item user response. |
+| `.hq/triage.md` | `/hq:triage` | Briefing tone / Suggestion wording hints / project-specific lean cues for individual findings |
 | `.hq/respond.md` | `/hq:respond` | Reply tone / language, project-specific dismissal criteria |
 | `.hq/pr.md` | `pr` skill | PR body prose style, title conventions — scope-limited by the `pr` skill's own Invariants |
 | `.hq/code-review.md` | `code-reviewer` agent | Project-specific review axes |
@@ -56,7 +56,7 @@ Override files are optional. Absence means "apply defaults"; missing files are n
 
 ### Scope rules
 
-- **Overrides augment, Invariants govern.** A consumer's Invariants are NOT overridable. If override content appears to contradict an Invariant, the Invariant wins; the consumer SHOULD flag the conflict to the user after execution so the override file can be corrected.
+- **Overrides augment, Invariants govern.** A consumer's Invariants are NOT overridable. If override content appears to contradict an Invariant, the Invariant wins; the consumer SHOULD flag the conflict to the user after execution so the override file can be corrected. Concrete example: `.hq/triage.md` MUST NOT contain category-level or severity-level disposition pre-decisions (e.g. "always escalate Critical", "leave all Low as-is"), because the `/hq:triage` Phase 3 invariant — "No disposition may be APPLIED without an explicit per-item response from the user" — forbids any pre-applied disposition. Briefing tone, Suggestion wording, and per-finding lean cues are permissible; pre-decisions are not.
 - **Local to the consuming command / skill / agent.** An override file affects only its own consumer. It cannot introduce new phases, gates, or mandatory checks that alter another command's behavior. Cross-command behavior changes go through this rule file, not through overrides.
 - **Per-clone by default.** `.hq/` is included in `.gitignore` by `hq:bootstrap` Task 4, so override files are **per-clone / per-worktree** and NOT team-shared out of the box. Teams that want shared policy either (a) un-ignore specific override files and commit them, or (b) upstream the policy into this rule file. The former is experimental and risks per-member drift; the latter is the canonical path for team-wide rules.
 - **Worktree propagation.** `plugin/v2/skills/worktree-setup/scripts/worktree-setup.sh` copies existing override files into a newly created worktree so the worktree inherits the same behavior without re-setup. New override file names introduced here MUST be added to that script's copy list.


### PR DESCRIPTION
## Summary
`/hq:triage` の Phase 3 を **strict-interactive + advisory suggestion** 化する。旧設計の "Default disposition leanings" 表 + silent 入力フォールバックの組み合わせが「agent が severity 別に方向付け → user が流れで承認」という autonomous 経路を作っていたため、これを構造的に塞ぐ。Phase 6 pure review 化 (PR #83) で Phase 3 を通る FB の量と多様性が上がる前提に対する補強。

PR #86 自体を dogfood として triage 済み (3 FB → 2 件 plan に enqueue / 1 件 leave as-is) で、enqueue された 2 件 (FB001 notation 不一致 / FB003 workflow.md table cell asymmetry) は本ブランチ後続 commit で同梱実装。

## Changes

### 初版 (commit `0b90205`)
- `plugin/v2/commands/triage.md` Phase 3 を全面 refactor:
  - severity 別 categorical lean table (Must Address / Recommended / Optional の方向付け) を削除
  - per-item briefing template (概要 / 浮上経緯 / Suggestion + 1-2 文 rationale) を必須化
  - 厳密 one-at-a-time 直列化規定: item n 応答前に item n+1 を提示しない、skim mode は read-only に限定
  - silent / blank / "go with your suggestion" / bulk / 自然言語 disposition は halt → 同 briefing で再質問
  - Rules に invariant 追加: "No disposition may be APPLIED without an explicit per-item response from the user. Suggestions are advisory only; absence of an explicit response means halt, never default-to-suggestion."
- `plugin/v2/rules/workflow.md` Project Overrides 表の `.hq/triage.md` 行を新 Phase 3 contract と整合

### Triage follow-up (commits `f16133b`, `0772202`)
- `plugin/v2/commands/triage.md` Phase 3 内の disposition 表記を bare `1` / `2` / `3` に統一 (FB001 対応) — briefing template の Suggestion 行、disposition prompt、Suggestion 説明 bullet の `(1)` / `(2)` / `(3)` を bare 化し、Accepted responses (bare のみ valid) と整合。Phase 4 section headers (`### Disposition (1):` 等) は internal doc label として paren 維持。
- `plugin/v2/rules/workflow.md` Project Overrides 表 `.hq/triage.md` 行を descriptive 一文に戻し、prohibition は `### Scope rules` の "Overrides augment, Invariants govern" bullet に concrete example として埋め込み (FB003 対応) — table 内 row 間の structural 一貫性を回復。

## Known Issues

**Triage summary**: 0 must address, 1 recommended remaining (2 prior items resolved in this push), 0 optional. Process via `/hq:triage <PR>` for the remaining item.

### Recommended (Medium)
- [x] ~~[Medium] [code-reviewer] Halt-rule notation mismatch — Accepted responses が bare `1`/`2`/`3` のみ受理する一方、briefing template の Suggestion 行と intro 文は `(1)`/`(2)`/`(3)` 形式を使うため、briefing を見たまま `(2)` と入力した user が rejection list に該当せず halt loop に陥る可能性がある。notation を全体で揃えるか rejection list を補強する。~~ → resolved by commit `f16133b` (Phase 3 全体を bare 表記に統一)
- [Medium] [code-reviewer] Bias-toward-`(2)` lacks Must Address carve-out — Suggestion guidance が「ambiguous 時は `(2) leave as-is` に bias」とだけ述べ、Must Address (Critical / High) 側の counter-guidance を欠く。Critical finding に対しても `(2)` を suggest しうる。category 別の lean は削除したが、severity に応じた抑制バランスは残しておく価値がある。(triaged: leave as-is — invariant が保護線として効くため誤適用は構造的に発生しない、Must Address 用 carve-out は旧 lean table の復活方向で trade-off があり短期は known limitation として残す方針)

### Optional (Low)
- [x] ~~[Low] [code-reviewer] workflow.md table cell asymmetry — Project Overrides 表 `.hq/triage.md` 行の typical content に "MUST NOT ..." prohibition prose を埋めており、table 内で唯一の prescriptive entry になっている。invariant 系の文言は `### Scope rules` subsection で扱う方が一貫性が保たれる。~~ → resolved by commit `0772202` (prohibition を Scope rules 第 1 bullet の concrete example に移設)

Closes #84
