### PR TITLE
docs: README と docs/workflow.md の PR#81/83/86 追従漏れを解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ For the full lifecycle, plan body schema, sync model, and per-command phase brea
 | `hq:task`     | Requirement (trigger)      | **What** needs to be done. Created by the user; consumed by `/hq:draft`. |
 | `hq:plan`     | Implementation plan        | **How** to do it. Created by `/hq:draft` as a sub-issue of `hq:task`. Drives `/hq:start`. |
 | `hq:pr`       | PR marker                  | Applied automatically by `/hq:start` on PR creation. |
+| `hq:manual`   | PR primary verification    | Applied alongside `hq:pr` when the plan carries `[manual] [primary]` (escape hatch) — reviewer must complete the PR's `## Primary Verification (manual)` block before merge. |
 | `hq:feedback` | Unresolved problem         | Carved out by `/hq:triage` (PR Known Issues) or `/hq:respond` (external comments). |
 | `hq:doc`      | Informational note         | Research findings worth preserving. Created manually. |
 | `hq:wip`      | Drafting / automation gate | Issue is being drafted; automation skips, manual commands pause and confirm. |

--- a/README.md
+++ b/README.md
@@ -88,29 +88,23 @@ Prerequisite: `gh` CLI authenticated (`gh auth status`).
 
 ## Bootstrap
 
-Run `/hq:bootstrap` once when initializing a new project. Pass `agents.md` as argument to also install `AGENTS.md`. Idempotent — safe to re-run.
+Run `/hq:bootstrap` once when initializing a new project. The skill **never silently skips or overwrites** — every change is confirmed with the user before applying. Safe to re-run; the HQ-managed block in `CLAUDE.md` is the only piece that bootstrap owns end-to-end, and even there a one-line diff summary is surfaced before write.
 
-| Target | Action | Note |
-|--------|--------|------|
-| `CLAUDE.md` | Create if missing | Filled from template with project info |
-| `AGENTS.md` | Create if missing | **Only when `agents.md` argument is given** |
-| `.claude/settings.local.json` | Deep-merge | Adds template keys + auto-detected platform permissions |
-| `.gitignore` | Append if missing | Adds `**/*.local.*` and `.hq/` |
+**Interactive build / test config** — the skill detects the project type (`*.xcodeproj` / `Package.swift` / `package.json` / `go.mod`) and proposes the matching install / dev / build / test / lint / format commands. The user then picks a **test strategy** — Unit (Claude runs tests autonomously) / E2E (Playwright via `hq:e2e-web`) / Manual (human-verified) — which is recorded into the HQ block.
 
-**Platform detection** for permissions:
-
-| Project type | Permissions added |
-|--------------|-------------------|
-| Xcode (`*.xcodeproj` / `*.xcworkspace`) | `swift-format`, `xcodebuild`, `xcrun` |
-| TypeScript (`package.json` / `tsconfig.json`) | `bun` |
-| Go (`go.mod`) | `go build`, `go vet` |
+| Target | What bootstrap does |
+|--------|---------------------|
+| `CLAUDE.md` | Create from template if missing. If present with `<!-- BEGIN HQ --> ... <!-- END HQ -->` markers, refresh only that block (Verification / Build / Test Strategy sub-sections); the rest is user territory. If present without markers, ask before appending the HQ block. |
+| `.claude/settings.local.json` | Add `attribution: { commit: "", pr: "" }` (suppresses Claude Code's default commit / PR footer). Existing values are never overwritten. |
+| `.gitignore` | Append `.hq/` (the HQ working directory — task context, FB files, scan reports) if missing. |
+| `.hq/xcodebuild-config.md` *(Xcode projects only)* | Delegated to the `hq:xcodebuild-config` skill — interactively captures Build / Run commands. |
 
 ## Design Philosophy
 
 The plugin is designed to **leave no trace in the target repository**:
 
-- **Committed** (only when missing): `CLAUDE.md`, `AGENTS.md` (opt-in), `.gitignore` entries (`**/*.local.*`, `.hq/`).
-- **Never committed** (gitignored): `.claude/settings.local.json`, `.hq/` (tasks, feedbacks, reports).
+- **Committed** (only when missing): `CLAUDE.md` (with the bootstrap-managed `<!-- BEGIN HQ --> ... <!-- END HQ -->` block), `.gitignore` entry (`.hq/`).
+- **Never committed** (gitignored): `.claude/settings.local.json`, `.hq/` (tasks, feedbacks, reports, retro).
 
 The workflow rule itself lives at `plugin/v2/rules/workflow.md` inside the plugin and is loaded on demand by each `/hq:*` command. Nothing is copied into the consumer project — editing that one file is the change.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For the full lifecycle, plan body schema, sync model, and per-command phase brea
 
 | Command  | Description |
 |----------|-------------|
-| `draft`   | Interactive brainstorm → create an `hq:plan` Issue from an `hq:task` |
+| `draft`   | Exploration-led brainstorm + Simplicity gatekeeper → create an `hq:plan` Issue (optionally from an `hq:task`) |
 | `start`   | Autonomous: branch → execute → acceptance → quality review → PR |
 | `triage`  | Triage PR body `## Known Issues` — add to plan / leave / escalate to `hq:feedback` |
 | `respond` | Respond to external PR review comments — fix / escalate / dismiss |

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ For the full lifecycle, plan body schema, sync model, and per-command phase brea
 |-------|-------------|
 | `code-reviewer`           | Reads `code-review` skill criteria; outputs report + FB files to `.hq/tasks/` |
 | `security-scanner`        | Reads `security-scan` skill criteria (Sonnet); outputs report to `.hq/tasks/` |
-| `integrity-checker`       | Reconciles `hq:plan` `## Plan Sketch` (esp. `**Impact**`) against the diff |
+| `integrity-checker`       | Reconciles `hq:plan` `## Editable surface` + `## Plan` against the diff (external grep: `[削除]` residuals, unmatched consumers) |
 | `review-comment-analyzer` | Read-only classification of PR review comments — Fix / Feedback / Dismiss |
 
-`/hq:start` Phase 6 (Quality Review) is **diff-kind aware**: `code-reviewer` and `integrity-checker` always run; `security-scanner` skips on doc-only diffs (credential / injection patterns structurally cannot appear there).
+`/hq:start` splits review into **Phase 6 (Self-Review)** — the orchestrator's pre-Quality-Review self-assessment across 3 axes (Plan alignment / Out-of-scope impact / Tunnel vision) — and **Phase 7 (Quality Review)** — pure review with **judgment-mode agent selection** by default (the orchestrator picks the agent subset as a third-party senior engineer; `full` mode applies the Diff Classification matrix as a fallback). Phase 7 FBs flow directly to `## Known Issues` without auto-fix.
 
 ## Issue Labels
 

--- a/plugin/v2/docs/workflow.md
+++ b/plugin/v2/docs/workflow.md
@@ -219,11 +219,16 @@ Phase 2: Parse Known Issues
 │    (### Must Address / ### Recommended / ### Optional)
 │  Each bullet = one triage item; preserve [Severity] [originating-agent] tags
 │
-Phase 3: Triage (interactive)
-│  For each item, ask user:
-│    (1) add to hq:plan
-│    (2) leave as-is
-│    (3) escalate to hq:feedback
+Phase 3: Triage (strict-interactive, advisory suggestion)
+│  For each item, sequentially (item n+1 is not shown until item n is answered):
+│    Briefing: 概要 / 浮上経緯 / advisory Suggestion + 1-2 文 rationale
+│    Disposition prompt — bare 1 / 2 / 3 only:
+│      1: add to hq:plan
+│      2: leave as-is
+│      3: escalate to hq:feedback
+│  Silent / blank / "go with your suggestion" / bulk / 自然言語 disposition は halt
+│    → 同 briefing で再質問 (Suggestions are advisory; no disposition is APPLIED
+│      without an explicit per-item response)
 │  (collect decisions; no writes yet)
 │
 Phase 4: Apply (batch)


### PR DESCRIPTION
## Summary
PR #81 / PR #83 / PR #86 で確立された新形式 (`## Editable surface` + `## Plan` ベースの integrity-checker scope、Phase 6 Self-Review + Phase 7 Quality Review judgment-mode default、`/hq:triage` strict-interactive + advisory suggestion) を README.md と plugin/v2/docs/workflow.md にピンポイントで追従。加えて、本 PR 内のレビュー過程で発覚した **bootstrap skill 関連の README 古い記述** (PR #83 の `hq:manual` label / `/hq:draft` の Simplicity gatekeeper + optional parent / bootstrap が今や AGENTS.md / `**/*.local.*` / platform permission を扱わない事実 / CLAUDE.md HQ block 構造) を全面更新。新規参入者が README から入って現行 plugin と乖離した記述に遭遇しない状態に揃える。

## Changes

### Plan #87 (元 scope)
- **`README.md`** — `integrity-checker` description を旧 `## Plan Sketch` / `**Impact**` 文言から新形式 `## Editable surface` + `## Plan` 受け取りの external-grep scope (`[削除]` residual / unmatched-consumer) 表現に書き換え。`/hq:start` Phase 6 説明を旧 "diff-kind aware" 単行から Phase 6 (Self-Review) / Phase 7 (Quality Review) 分割 + judgment-mode agent selection default 表現に置換。
- **`plugin/v2/docs/workflow.md`** — `/hq:triage` Phase 3 ブロックを PR #86 反映に書き換え: strict-interactive + advisory suggestion + halt-on-silent + bare `1`/`2`/`3` notation を Phase Map に明示。

### Scope 拡張 (本 PR レビュー過程で追加)
- **Commands 表 `draft` 行** — `Interactive brainstorm` → `Exploration-led brainstorm + Simplicity gatekeeper`、`from an hq:task` → `(optionally from an hq:task)` (PR #81 / hq:workflow § Issue Hierarchy の親なし top-level plan に追従)。
- **Issue Labels 表 `hq:manual` 行追加** — PR #83 で導入された `[manual] [primary]` escape hatch の PR marker。`pr` skill が `hq:pr` と並行で付与し、`## Primary Verification (manual)` block 完了を merge 前 reviewer 義務として明示。
- **Bootstrap セクション全面書き換え** — 現行 `hq:bootstrap` SKILL.md の実態に合わせて update: (a) `agents.md` 引数 / `AGENTS.md` インストールの記述削除 (機能なし)、(b) `.claude/settings.local.json` は `attribution` のみで platform permissions の自動付与は廃止済を反映、(c) `.gitignore` は `.hq/` 単独 (`**/*.local.*` は追加されない)、(d) "Platform detection for permissions" 表を削除、(e) Interactive build/test config 収集 / test strategy 選択 / `<!-- BEGIN HQ --> ... <!-- END HQ -->` HQ block / `hq:xcodebuild-config` 連携を追加。
- **Design Philosophy 箇条書き** — `AGENTS.md (opt-in)` および `**/*.local.*` の obsolete 記述を削除し、現行 bootstrap が実際にコミット対象とするもの (`CLAUDE.md` の HQ block + `.hq/` の gitignore) のみに絞る。

## Notes

新規 symbol / heading / marker は導入していない。新表現は全て上流 PR (`plugin/v2/commands/triage.md`, `plugin/v2/rules/workflow.md` § Phase 6 / § Phase 7 / § Issue Hierarchy, `plugin/v2/skills/bootstrap/SKILL.md`, `plugin/v2/skills/pr/SKILL.md`) で既に確立済の語彙を README / docs に追従させたもの。

### Plan からの scope 拡張について
本 PR の plan #87 `## Editable surface` 当初宣言は `README.md` (integrity-checker 行 + Phase 6 行) と `plugin/v2/docs/workflow.md` (triage Phase 3 ブロック) のピンポイント書き換えに限定されていた。PR 作成後のレビューで `hq:bootstrap` 関連の同種の追従漏れが発覚したため、surface (`README.md`) 自体は不変のまま entry note の範囲を拡張する形で同 PR にスタック対応。本来は plan の `## Editable surface` 注記を Boundary expansion protocol に従って事前更新するのが正だが、PR 公開後の小規模追随として一括処理を選択した。

Closes #87