### PR TITLE
feat(archive): add cancel mode for un-merged PR close-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ HQ separates a feature from idea to merge into a small set of command-scoped ope
                  (intervention #1)   (intervention #2)
                   review hq:plan       review hq:pr
                          ↓                   ↓
- hq:task ─/hq:draft─→ hq:plan ─/hq:start─→ hq:pr ──┬─ merge ─/hq:archive─→
+ hq:task ─/hq:draft─→ hq:plan ─/hq:start─→ hq:pr ──┬─ merge ──────────/hq:archive────────→ (tasks/done/)
+                                                   ├─ close w/o merge ─/hq:archive cancel→ (tasks/cancel/)
                                                    │
                                                    ├─ /hq:triage   (Known Issues from PR body)
                                                    └─ /hq:respond  (external review comments)
@@ -34,7 +35,7 @@ For the full lifecycle, plan body schema, sync model, and per-command phase brea
 | `start`   | Autonomous: branch → execute → acceptance → quality review → PR |
 | `triage`  | Triage PR body `## Known Issues` — add to plan / leave / escalate to `hq:feedback` |
 | `respond` | Respond to external PR review comments — fix / escalate / dismiss |
-| `archive` | Safely close a merged PR's branch — verify + archive task folder + delete local branch |
+| `archive` | Safely close the current branch — **done** (PR merged → `tasks/done/`) or **cancel** (`archive cancel`: closes PR without merging → `tasks/cancel/`) |
 | `swift-protocol-shadow` | Detect protocol default implementation shadowing in Swift ([flow](plugin/v2/docs/swift-protocol-shadow-flow.md)) |
 
 ### Skills (analysis criteria)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ HQ separates a feature from idea to merge into a small set of command-scoped ope
                   review hq:plan       review hq:pr
                          ↓                   ↓
  hq:task ─/hq:draft─→ hq:plan ─/hq:start─→ hq:pr ──┬─ merge ──────────/hq:archive────────→ (tasks/done/)
-                                                   ├─ close w/o merge ─/hq:archive cancel→ (tasks/cancel/)
+                                                   ├─ close w/o merge ─/hq:archive cancel→ (tasks/canceled/)
                                                    │
                                                    ├─ /hq:triage   (Known Issues from PR body)
                                                    └─ /hq:respond  (external review comments)
@@ -35,7 +35,7 @@ For the full lifecycle, plan body schema, sync model, and per-command phase brea
 | `start`   | Autonomous: branch → execute → acceptance → quality review → PR |
 | `triage`  | Triage PR body `## Known Issues` — add to plan / leave / escalate to `hq:feedback` |
 | `respond` | Respond to external PR review comments — fix / escalate / dismiss |
-| `archive` | Safely close the current branch — **done** (PR merged → `tasks/done/`) or **cancel** (`archive cancel`: closes PR without merging → `tasks/cancel/`) |
+| `archive` | Safely close the current branch — **done** (PR merged → `tasks/done/`) or **cancel** (`archive cancel`: closes PR without merging → `tasks/canceled/`) |
 | `swift-protocol-shadow` | Detect protocol default implementation shadowing in Swift ([flow](plugin/v2/docs/swift-protocol-shadow-flow.md)) |
 
 ### Skills (analysis criteria)

--- a/plugin/v2/commands/archive.md
+++ b/plugin/v2/commands/archive.md
@@ -1,25 +1,35 @@
 ---
 name: archive
-description: Safely close the current work branch — verify PR merged + no pending FBs, then archive and clean up
+description: Safely close the current work branch — done mode (PR merged → tasks/done/) or cancel mode (PR closed without merge → tasks/cancel/)
 allowed-tools: Read, Glob, Bash(git:*), Bash(gh:*), Bash(bash:*), Bash(ls:*), Bash(mv:*), Bash(mkdir:*), TaskCreate, TaskUpdate
 ---
 
 # ARCHIVE — Safe Branch Closure
 
-This command closes out a completed work branch by:
+This command closes out the current work branch in one of two modes:
 
-1. Verifying the PR is merged
-2. Verifying no pending FB files remain
-3. Moving `.hq/tasks/<branch-dir>/` to `.hq/tasks/done/<branch-dir>/`
-4. Switching to the base branch
-5. Deleting the local feature branch
-6. Clearing the focus memory entry
+| Mode | Trigger | Precondition | Folder destination | Issue close |
+|---|---|---|---|---|
+| **done** (default) | `/hq:archive` | PR is `MERGED` | `.hq/tasks/done/<branch-dir>/` | Auto (via PR `Closes #<plan>`) |
+| **cancel** | `/hq:archive cancel` | PR is `OPEN` / `CLOSED` / absent (anything except `MERGED`) | `.hq/tasks/cancel/<branch-dir>/` | Explicit `gh issue close --reason "not planned"` |
 
-If the pre-checks fail, the command **stops** and reports what remains. There is no interactive confirmation for the archive itself — if safety checks pass, the archive proceeds unconditionally.
+In **done mode** the command verifies the PR is merged, then archives + cleans up. In **cancel mode** the command closes the PR (if still open) without merging, explicitly closes the `hq:plan` Issue with reason `not planned`, archives the task folder to `cancel/`, then cleans up the local branch.
 
-**Security**: This command deletes a local branch. It never pushes, never force-pushes, and never touches remote branches.
+If the pre-checks for the selected mode fail, the command **stops** and reports what remains. The explicit `cancel` argument is itself the confirmation — once pre-checks pass, the command proceeds unconditionally in either mode.
+
+**Security**: This command deletes the local branch and (in cancel mode) closes the PR + Issue on GitHub. It never pushes, never force-pushes, never deletes remote branches, and never touches branches other than the current feature branch.
 
 **`hq:workflow`** — shorthand for `${CLAUDE_PLUGIN_ROOT}/plugin/v2/rules/workflow.md` (plugin-internal source of truth). Read it with the Read tool when this command starts so all phases have Focus, FB Lifecycle, etc. available. All `hq:workflow § <name>` citations refer to sections of that file.
+
+## Argument Parsing
+
+Parse `$ARGUMENTS`:
+
+- Empty → **done mode**
+- `cancel` (case-insensitive, trimmed) → **cancel mode**
+- Anything else → ABORT with usage: `Usage: /hq:archive [cancel]`
+
+Hold the resolved mode in conversation state — every subsequent phase branches on it.
 
 ## Progress Tracking
 
@@ -28,13 +38,14 @@ Use Claude Code's task UI (`TaskCreate` / `TaskUpdate`). Create all phases as ta
 | Task subject | activeForm |
 |---|---|
 | Resolve focus | Resolving focus |
-| Pre-check: PR merged | Checking PR merge state |
+| Pre-check: PR state | Checking PR state |
 | Pre-check: pending FBs | Checking pending FBs |
+| Close PR + Issue (cancel only) | Closing PR and Issue |
 | Archive task folder | Archiving task folder |
 | Clean up branch | Cleaning up branch |
 | Report results | Reporting results |
 
-Set each to `in_progress` when starting and `completed` when done. If a pre-check aborts the command, mark remaining phases as `completed` with a brief note and stop.
+Set each to `in_progress` when starting and `completed` when done. If a pre-check aborts the command, mark remaining phases as `completed` with a brief note and stop. The "Close PR + Issue" task is `completed` with note `n/a (done mode)` when running in done mode.
 
 ## Context
 
@@ -46,13 +57,13 @@ Set each to `in_progress` when starting and `completed` when done. If a pre-chec
 Read `.hq/tasks/<branch-dir>/context.md` for the **current branch** (branch-dir = branch name with `/` → `-`). Extract:
 
 - `plan` — `hq:plan` Issue number
-- `source` — `hq:task` Issue number
+- `source` — `hq:task` Issue number (may be absent — plans without a parent task)
 - `branch` — original branch name (should match current branch)
-- `base_branch` — the branch this feature branch was created from (captured at `/hq:start` Phase 3 — see `hq:workflow § Focus`). **Hold this in conversation state** — Phase 4 archives `context.md` away, and Phase 5 needs the base to check out of the feature branch.
+- `base_branch` — the branch this feature branch was created from (captured at `/hq:start` Phase 3 — see `hq:workflow § Focus`). **Hold this in conversation state** — Phase 5 archives `context.md` away, and Phase 6 needs the base to check out of the feature branch.
 
 If `context.md` is not found, ABORT with a message explaining that no `.hq/tasks/` entry matches the current branch and that `/hq:archive` closes out the current branch's task folder — the user can switch to the correct branch and retry.
 
-## Phase 2: Pre-check — PR Merged?
+## Phase 2: Pre-check — PR State
 
 Find the PR associated with this branch:
 
@@ -60,12 +71,23 @@ Find the PR associated with this branch:
 gh pr list --head "<current-branch>" --state all --json number,state,url --limit 5
 ```
 
-- If **no PR exists**, ABORT with a message saying the PR has not been created yet and the user should complete `/hq:start` to create it.
-- If **PR state is OPEN**, ABORT with a message saying PR #<n> is still open and the command should be retried after review/merge completes (include the URL).
-- If **PR state is CLOSED** (not merged), ABORT with a message saying PR #<n> was closed without merging and the user must decide how to proceed (reopen / manual cleanup), including the URL.
-- If **PR state is MERGED**, proceed.
+Hold the PR number, state, and URL in conversation state — later phases (and the report) reference them.
 
-## Phase 3: Pre-check — Pending FBs?
+**Done mode** acceptance:
+
+- No PR → ABORT (`PR not created — complete /hq:start first.`)
+- `OPEN` → ABORT (`PR #<n> is still open. Retry after merge: <url>`)
+- `CLOSED` (not merged) → ABORT (`PR #<n> was closed without merging. To archive as canceled, run: /hq:archive cancel — URL: <url>`)
+- `MERGED` → proceed
+
+**Cancel mode** acceptance:
+
+- No PR → proceed (note: no PR to close)
+- `OPEN` → proceed (Phase 4 will close it)
+- `CLOSED` (not merged) → proceed (note: PR already closed)
+- `MERGED` → ABORT (`PR #<n> was merged — cancel mode is for un-merged closes. Use /hq:archive (without 'cancel') instead. URL: <url>`)
+
+## Phase 3: Pre-check — Pending FBs
 
 Check `.hq/tasks/<branch-dir>/feedbacks/` for any non-`done/` files:
 
@@ -73,8 +95,10 @@ Check `.hq/tasks/<branch-dir>/feedbacks/` for any non-`done/` files:
 find .hq/tasks/<branch-dir>/feedbacks -maxdepth 1 -type f -name 'FB*.md' 2>/dev/null
 ```
 
-- If **no pending FBs**, proceed.
-- If **pending FBs exist**, ABORT with the list:
+**Done mode**:
+
+- No pending FBs → proceed.
+- Pending FBs exist → ABORT with the list:
   ```
   Cannot archive — pending FB files:
     - FB003.md
@@ -82,68 +106,138 @@ find .hq/tasks/<branch-dir>/feedbacks -maxdepth 1 -type f -name 'FB*.md' 2>/dev/
   → These should have been moved to feedbacks/done/ during /hq:start PR creation.
     Resolve or move them manually, then retry.
   ```
+  This is defensive — in a normal `/hq:start` → PR flow, all FBs are moved to `done/` when the PR is created. Pending files here indicate an abnormal state.
 
-This is a defensive check — in a normal `/hq:start` → PR flow, all FBs are moved to `done/` when the PR is created. Pending files here indicate an abnormal state.
+**Cancel mode**:
 
-## Phase 4: Archive Task Folder
+- No pending FBs → proceed silently.
+- Pending FBs exist → **do not abort**. Record the list and include it in the Phase 7 report. Rationale: when the work is being canceled, unresolved FBs are part of the abandoned state — they will travel with the folder to `cancel/` for the audit trail. The user has already signaled cancel intent via the explicit argument.
 
-Ensure the archive destination exists:
+## Phase 4: Close PR + Issue (cancel mode only)
+
+**Skip this phase entirely in done mode.** Mark its task `completed` with note `n/a (done mode)` and move to Phase 5.
+
+In cancel mode, perform the GitHub-side close operations **before** moving local files. If any of these fails, abort with the failure — the workspace stays consistent with GitHub state.
+
+### 4a. Close the PR (if open)
+
+If Phase 2 recorded PR state `OPEN`:
 
 ```bash
-mkdir -p .hq/tasks/done
+gh pr close <pr-number> --comment "Closed via /hq:archive cancel — work canceled without merging."
 ```
 
-Move the task folder:
+Do **not** pass `--delete-branch`. Remote branch lifecycle is left to repo settings / manual cleanup, symmetric with done mode (which never deletes remote branches either).
+
+If the PR was already `CLOSED` or absent, skip 4a.
+
+### 4b. Close the hq:plan Issue
+
+The `Closes #<plan>` linkage on the PR auto-closes the plan **only on merge**. In cancel mode there is no merge, so close the plan Issue explicitly:
 
 ```bash
+gh issue close <plan> --reason "not planned" --comment "<comment>"
+```
+
+Where `<comment>` is one of:
+
+- PR existed (any non-merged state): `Canceled via /hq:archive cancel. PR #<n> closed without merging: <url>`
+- No PR existed: `Canceled via /hq:archive cancel. No PR was created.`
+
+The parent `hq:task` Issue is **not** touched — task-level requirements may still be valid; only this particular plan attempt is canceled. The user can manually close the task later if appropriate.
+
+## Phase 5: Archive Task Folder
+
+Pick the archive root based on mode:
+
+- done mode → `.hq/tasks/done`
+- cancel mode → `.hq/tasks/cancel`
+
+Ensure the destination exists and move:
+
+```bash
+archive_root=".hq/tasks/<done|cancel>"   # selected by mode
+mkdir -p "$archive_root"
+
 src=".hq/tasks/<branch-dir>"
-dst=".hq/tasks/done/<branch-dir>"
+dst="$archive_root/<branch-dir>"
 
 # If destination already exists, append a timestamp suffix
 if [[ -e "$dst" ]]; then
-  dst=".hq/tasks/done/<branch-dir>-$(date +%Y%m%d-%H%M%S)"
+  dst="$archive_root/<branch-dir>-$(date +%Y%m%d-%H%M%S)"
 fi
 
 mv "$src" "$dst"
 ```
 
-## Phase 5: Clean Up Branch
+Hold the final `dst` path in conversation state for the report.
 
-1. Use the `base_branch` value captured from `context.md` in Phase 1. If that field was absent (legacy `context.md` from before the field was introduced), fall back to the rest of the resolution chain per `hq:workflow § Branch Rules`: `.hq/settings.json` `base_branch` → `git symbolic-ref --short refs/remotes/origin/HEAD` → `main`. The `context.md` path itself is no longer available at this point — Phase 4 archived the file.
+## Phase 6: Clean Up Branch
+
+1. Use the `base_branch` value captured from `context.md` in Phase 1. If that field was absent (legacy `context.md` from before the field was introduced), fall back to the rest of the resolution chain per `hq:workflow § Branch Rules`: `.hq/settings.json` `base_branch` → `git symbolic-ref --short refs/remotes/origin/HEAD` → `main`. The `context.md` path itself is no longer available at this point — Phase 5 archived the file.
 2. Switch to base:
    ```bash
    git checkout <base>
    ```
 3. Delete the local feature branch:
-   ```bash
-   git branch -d <feature-branch>
-   ```
-   - If `-d` refuses (branch not fully merged from git's local POV, e.g., squash-merged on GitHub), retry with `-D`:
+   - **Done mode**:
+     ```bash
+     git branch -d <feature-branch>
+     ```
+     If `-d` refuses (branch not fully merged from git's local POV, e.g., squash-merged on GitHub), retry with `-D`:
      ```bash
      git branch -D <feature-branch>
      ```
      This is safe because we already confirmed the PR was merged in Phase 2.
+   - **Cancel mode**:
+     ```bash
+     git branch -D <feature-branch>
+     ```
+     Use `-D` directly — by definition the branch is not merged into base, so `-d` would always refuse. The explicit `cancel` argument is the user's authorization to drop the unmerged commits.
 
-## Phase 6: Update Memory
+## Phase 7: Update Memory
 
-Clear the focus entry in your memory. The `hq:plan` Issue is already closed by GitHub on PR merge (via the `Closes #<plan>` link), so no `gh issue close` call is needed here.
+Clear the focus entry in your memory.
 
-## Phase 7: Report
+- **Done mode**: the `hq:plan` Issue is already closed by GitHub on PR merge (via `Closes #<plan>`); no `gh issue close` call is needed.
+- **Cancel mode**: Phase 4b already closed the `hq:plan` Issue explicitly.
 
-Summarize:
+In both modes, the parent `hq:task` Issue (if any) is left untouched.
 
+## Phase 8: Report
+
+Mode-aware summary.
+
+**Done mode**:
+
+- **Mode**: `done`
 - **Archived**: `.hq/tasks/<branch-dir>/` → `.hq/tasks/done/<branch-dir>[-timestamp]/`
 - **Branch deleted**: `<feature-branch>`
 - **Now on**: `<base-branch>`
 - **hq:plan**: #<plan> (closed on PR merge)
 - **PR**: #<pr> (merged, <url>)
 
+**Cancel mode**:
+
+- **Mode**: `cancel`
+- **Archived**: `.hq/tasks/<branch-dir>/` → `.hq/tasks/cancel/<branch-dir>[-timestamp]/`
+- **Branch force-deleted**: `<feature-branch>`
+- **Now on**: `<base-branch>`
+- **hq:plan**: #<plan> (closed with reason "not planned")
+- **PR**: #<pr> (closed without merging, <url>) — or `(no PR was created)` if Phase 2 found none
+- **Pending FBs at cancel time** (if any): list filenames from Phase 3 with a note that they live under `.hq/tasks/cancel/<branch-dir>/feedbacks/` for the audit trail.
+
 ## Rules
 
 - **Stop on pre-check failure** — never force-archive. The user must resolve prerequisites themselves.
-- **No interactive confirmation for archival** — when pre-checks pass, move and clean up unconditionally.
+- **Explicit `cancel` argument is the confirmation** — no extra interactive prompt. Mistyping is handled by the strict argument parser (only empty or `cancel` accepted).
+- **Mode is set once at Phase 0 (argument parsing) and never changes** — every phase branches on the same mode value.
 - **No `hq:feedback` creation** — this command does NOT escalate anything. Escalation happens via `/hq:triage` during PR review, before merge.
-- **Never push / force-push** — all operations are local.
+- **Never push / force-push** — all git operations are local.
+- **Never delete remote branches** — symmetric across modes. `gh pr close` runs without `--delete-branch`.
 - **Never use `git branch -D` on the base branch** — always switch off the feature branch first.
+- **Never touch the parent `hq:task` Issue** — task-level requirements outlive a single canceled plan.
 - **Never use `--no-verify`** — not applicable here, but the general hook-bypass prohibition stands.
-- **Timestamp collisions** — if `.hq/tasks/done/<branch-dir>/` already exists, append a timestamp suffix rather than overwriting.
+- **Timestamp collisions** — if `.hq/tasks/<done|cancel>/<branch-dir>/` already exists, append a timestamp suffix rather than overwriting.
+- **Cancel mode aborts on `MERGED` PR** — a merged PR cannot be "canceled"; the user must run plain `/hq:archive` to finalize.
+- **Done mode aborts on any non-`MERGED` state** — including `CLOSED` (not merged), which is redirected to `/hq:archive cancel`.

--- a/plugin/v2/commands/archive.md
+++ b/plugin/v2/commands/archive.md
@@ -1,6 +1,6 @@
 ---
 name: archive
-description: Safely close the current work branch — done mode (PR merged → tasks/done/) or cancel mode (PR closed without merge → tasks/cancel/)
+description: Safely close the current work branch — done mode (PR merged → tasks/done/) or cancel mode (PR closed without merge → tasks/canceled/)
 allowed-tools: Read, Glob, Bash(git:*), Bash(gh:*), Bash(bash:*), Bash(ls:*), Bash(mv:*), Bash(mkdir:*), TaskCreate, TaskUpdate
 ---
 
@@ -11,9 +11,9 @@ This command closes out the current work branch in one of two modes:
 | Mode | Trigger | Precondition | Folder destination | Issue close |
 |---|---|---|---|---|
 | **done** (default) | `/hq:archive` | PR is `MERGED` | `.hq/tasks/done/<branch-dir>/` | Auto (via PR `Closes #<plan>`) |
-| **cancel** | `/hq:archive cancel` | PR is `OPEN` / `CLOSED` / absent (anything except `MERGED`) | `.hq/tasks/cancel/<branch-dir>/` | Explicit `gh issue close --reason "not planned"` |
+| **cancel** | `/hq:archive cancel` | PR is `OPEN` / `CLOSED` / absent (anything except `MERGED`) | `.hq/tasks/canceled/<branch-dir>/` | Explicit `gh issue close --reason "not planned"` |
 
-In **done mode** the command verifies the PR is merged, then archives + cleans up. In **cancel mode** the command closes the PR (if still open) without merging, explicitly closes the `hq:plan` Issue with reason `not planned`, archives the task folder to `cancel/`, then cleans up the local branch.
+In **done mode** the command verifies the PR is merged, then archives + cleans up. In **cancel mode** the command closes the PR (if still open) without merging, explicitly closes the `hq:plan` Issue with reason `not planned`, archives the task folder to `canceled/`, then cleans up the local branch.
 
 If the pre-checks for the selected mode fail, the command **stops** and reports what remains. The explicit `cancel` argument is itself the confirmation — once pre-checks pass, the command proceeds unconditionally in either mode.
 
@@ -111,7 +111,7 @@ find .hq/tasks/<branch-dir>/feedbacks -maxdepth 1 -type f -name 'FB*.md' 2>/dev/
 **Cancel mode**:
 
 - No pending FBs → proceed silently.
-- Pending FBs exist → **do not abort**. Record the list and include it in the Phase 7 report. Rationale: when the work is being canceled, unresolved FBs are part of the abandoned state — they will travel with the folder to `cancel/` for the audit trail. The user has already signaled cancel intent via the explicit argument.
+- Pending FBs exist → **do not abort**. Record the list and include it in the Phase 7 report. Rationale: when the work is being canceled, unresolved FBs are part of the abandoned state — they will travel with the folder to `canceled/` for the audit trail. The user has already signaled cancel intent via the explicit argument.
 
 ## Phase 4: Close PR + Issue (cancel mode only)
 
@@ -151,12 +151,12 @@ The parent `hq:task` Issue is **not** touched — task-level requirements may st
 Pick the archive root based on mode:
 
 - done mode → `.hq/tasks/done`
-- cancel mode → `.hq/tasks/cancel`
+- cancel mode → `.hq/tasks/canceled`
 
 Ensure the destination exists and move:
 
 ```bash
-archive_root=".hq/tasks/<done|cancel>"   # selected by mode
+archive_root=".hq/tasks/<done|canceled>"   # selected by mode
 mkdir -p "$archive_root"
 
 src=".hq/tasks/<branch-dir>"
@@ -220,12 +220,12 @@ Mode-aware summary.
 **Cancel mode**:
 
 - **Mode**: `cancel`
-- **Archived**: `.hq/tasks/<branch-dir>/` → `.hq/tasks/cancel/<branch-dir>[-timestamp]/`
+- **Archived**: `.hq/tasks/<branch-dir>/` → `.hq/tasks/canceled/<branch-dir>[-timestamp]/`
 - **Branch force-deleted**: `<feature-branch>`
 - **Now on**: `<base-branch>`
 - **hq:plan**: #<plan> (closed with reason "not planned")
 - **PR**: #<pr> (closed without merging, <url>) — or `(no PR was created)` if Phase 2 found none
-- **Pending FBs at cancel time** (if any): list filenames from Phase 3 with a note that they live under `.hq/tasks/cancel/<branch-dir>/feedbacks/` for the audit trail.
+- **Pending FBs at cancel time** (if any): list filenames from Phase 3 with a note that they live under `.hq/tasks/canceled/<branch-dir>/feedbacks/` for the audit trail.
 
 ## Rules
 
@@ -238,6 +238,6 @@ Mode-aware summary.
 - **Never use `git branch -D` on the base branch** — always switch off the feature branch first.
 - **Never touch the parent `hq:task` Issue** — task-level requirements outlive a single canceled plan.
 - **Never use `--no-verify`** — not applicable here, but the general hook-bypass prohibition stands.
-- **Timestamp collisions** — if `.hq/tasks/<done|cancel>/<branch-dir>/` already exists, append a timestamp suffix rather than overwriting.
+- **Timestamp collisions** — if `.hq/tasks/<done|canceled>/<branch-dir>/` already exists, append a timestamp suffix rather than overwriting.
 - **Cancel mode aborts on `MERGED` PR** — a merged PR cannot be "canceled"; the user must run plain `/hq:archive` to finalize.
 - **Done mode aborts on any non-`MERGED` state** — including `CLOSED` (not merged), which is redirected to `/hq:archive cancel`.

--- a/plugin/v2/docs/workflow.md
+++ b/plugin/v2/docs/workflow.md
@@ -22,14 +22,14 @@ These two review points are the workflow's center of gravity. Everything downstr
                   review hq:plan       review hq:pr
                          ↓                   ↓
  hq:task ─/hq:draft─→ hq:plan ─/hq:start─→ hq:pr ──┬─ merge ──────────/hq:archive────────→ (tasks/done/)
-                                                   ├─ close w/o merge ─/hq:archive cancel→ (tasks/cancel/)
+                                                   ├─ close w/o merge ─/hq:archive cancel→ (tasks/canceled/)
                                                    │
                                                    ├─ /hq:triage   (Known Issues from PR body)
                                                    └─ /hq:respond  (external review comments)
 ```
 
 - **Creation path** (produces artifacts): `/hq:draft` → `/hq:start` → (merge) → `/hq:archive`.
-- **Cancel path**: when the produced PR is closed without merging (decision after intervention #2), `/hq:archive cancel` closes PR + `hq:plan` Issue and archives the task folder under `.hq/tasks/cancel/` for the audit trail.
+- **Cancel path**: when the produced PR is closed without merging (decision after intervention #2), `/hq:archive cancel` closes PR + `hq:plan` Issue and archives the task folder under `.hq/tasks/canceled/` for the audit trail.
 - **Response tools** (invoked at the user's discretion after intervention #2, zero or more times, in any order): `/hq:triage` for in-PR Known Issues, `/hq:respond` for external review comments.
 
 ## Lifecycle Overview
@@ -43,7 +43,7 @@ Creation path:
 3. **Merge the `hq:pr`** — GitHub auto-closes `hq:plan` via `Closes #<plan>`.
 4. **`/hq:archive`** — safety-checked close-out in one of two modes:
    - **done mode** (`/hq:archive`): requires PR merged + no pending FBs, then archives `.hq/tasks/<branch-dir>/` → `.hq/tasks/done/` and deletes the local feature branch. The `hq:plan` Issue was already closed by the merge.
-   - **cancel mode** (`/hq:archive cancel`): for the case where the PR is being abandoned (closed without merging). Closes the PR if still open, explicitly closes the `hq:plan` Issue with reason `not planned`, archives the task folder → `.hq/tasks/cancel/`, and force-deletes the local feature branch. The parent `hq:task` Issue is untouched.
+   - **cancel mode** (`/hq:archive cancel`): for the case where the PR is being abandoned (closed without merging). Closes the PR if still open, explicitly closes the `hq:plan` Issue with reason `not planned`, archives the task folder → `.hq/tasks/canceled/`, and force-deletes the local feature branch. The parent `hq:task` Issue is untouched.
 
 Response tools (invoked between intervention #2 and merge, at the user's discretion):
 
@@ -278,7 +278,7 @@ Phase 2: Pre-check PR
 Phase 3: Pre-check FBs
 │  Any pending files in feedbacks/ (not done/)?
 │  done   → yes → ABORT with list ; no → proceed
-│  cancel → record list (do NOT abort); travels with folder to cancel/
+│  cancel → record list (do NOT abort); travels with folder to canceled/
 │
 Phase 4: Close PR + Issue        ← cancel mode only (done mode skips)
 │  if PR state was OPEN:
@@ -288,7 +288,7 @@ Phase 4: Close PR + Issue        ← cancel mode only (done mode skips)
 │
 Phase 5: Archive folder
 │  done   → mv .hq/tasks/<branch-dir> → .hq/tasks/done/<branch-dir>[-timestamp]
-│  cancel → mv .hq/tasks/<branch-dir> → .hq/tasks/cancel/<branch-dir>[-timestamp]
+│  cancel → mv .hq/tasks/<branch-dir> → .hq/tasks/canceled/<branch-dir>[-timestamp]
 │
 Phase 6: Branch cleanup
 │  git checkout <base>
@@ -308,8 +308,8 @@ Phase 8: Report  (mode-aware)
 - **Explicit `cancel` argument is the confirmation** — no additional interactive prompt. The strict argument parser (only empty or `cancel` accepted) catches typos.
 - **Mode-symmetric remote-branch policy** — neither mode deletes remote branches. `gh pr close` runs without `--delete-branch`; remote cleanup is left to repo settings / manual action.
 - **Cancel touches GitHub state**: closes the PR (if open) and explicitly closes the `hq:plan` Issue with reason `not planned`. The parent `hq:task` Issue is untouched — task-level requirements outlive a single canceled plan attempt.
-- **Folder structure is parallel**: `.hq/tasks/done/<branch-dir>/` and `.hq/tasks/cancel/<branch-dir>/` live side-by-side. `find-plan-branch.sh` scans only depth-2 `context.md` files, so archived contexts in either bucket do not collide with live contexts.
-- **Pending-FB handling diverges by mode**: done aborts (defensive — pending FBs are an abnormal post-`/hq:start` state); cancel records and proceeds (the FBs are part of the abandoned state and ride along to `cancel/` for the audit trail).
+- **Folder structure is parallel**: `.hq/tasks/done/<branch-dir>/` and `.hq/tasks/canceled/<branch-dir>/` live side-by-side. `find-plan-branch.sh` scans only depth-2 `context.md` files, so archived contexts in either bucket do not collide with live contexts.
+- **Pending-FB handling diverges by mode**: done aborts (defensive — pending FBs are an abnormal post-`/hq:start` state); cancel records and proceeds (the FBs are part of the abandoned state and ride along to `canceled/` for the audit trail).
 - **Never pushes / force-pushes** — all git operations are local.
 - **No `hq:feedback` escalation** — escalation lives in `/hq:triage` during PR review, before merge.
 

--- a/plugin/v2/docs/workflow.md
+++ b/plugin/v2/docs/workflow.md
@@ -21,13 +21,15 @@ These two review points are the workflow's center of gravity. Everything downstr
                  (intervention #1)   (intervention #2)
                   review hq:plan       review hq:pr
                          ↓                   ↓
- hq:task ─/hq:draft─→ hq:plan ─/hq:start─→ hq:pr ──┬─ merge ─/hq:archive─→
+ hq:task ─/hq:draft─→ hq:plan ─/hq:start─→ hq:pr ──┬─ merge ──────────/hq:archive────────→ (tasks/done/)
+                                                   ├─ close w/o merge ─/hq:archive cancel→ (tasks/cancel/)
                                                    │
                                                    ├─ /hq:triage   (Known Issues from PR body)
                                                    └─ /hq:respond  (external review comments)
 ```
 
 - **Creation path** (produces artifacts): `/hq:draft` → `/hq:start` → (merge) → `/hq:archive`.
+- **Cancel path**: when the produced PR is closed without merging (decision after intervention #2), `/hq:archive cancel` closes PR + `hq:plan` Issue and archives the task folder under `.hq/tasks/cancel/` for the audit trail.
 - **Response tools** (invoked at the user's discretion after intervention #2, zero or more times, in any order): `/hq:triage` for in-PR Known Issues, `/hq:respond` for external review comments.
 
 ## Lifecycle Overview
@@ -39,7 +41,9 @@ Creation path:
 2. **`/hq:start <hq:plan>`** — autonomous: branch → execute → acceptance → quality review → PR (labeled `hq:pr`).
    → **User intervention #2**: review the `hq:pr`, then choose how to proceed.
 3. **Merge the `hq:pr`** — GitHub auto-closes `hq:plan` via `Closes #<plan>`.
-4. **`/hq:archive`** — safety-checked close-out: requires PR merged + no pending FBs, then archives `.hq/tasks/<branch-dir>/` and deletes the local feature branch.
+4. **`/hq:archive`** — safety-checked close-out in one of two modes:
+   - **done mode** (`/hq:archive`): requires PR merged + no pending FBs, then archives `.hq/tasks/<branch-dir>/` → `.hq/tasks/done/` and deletes the local feature branch. The `hq:plan` Issue was already closed by the merge.
+   - **cancel mode** (`/hq:archive cancel`): for the case where the PR is being abandoned (closed without merging). Closes the PR if still open, explicitly closes the `hq:plan` Issue with reason `not planned`, archives the task folder → `.hq/tasks/cancel/`, and force-deletes the local feature branch. The parent `hq:task` Issue is untouched.
 
 Response tools (invoked between intervention #2 and merge, at the user's discretion):
 
@@ -248,41 +252,66 @@ Phase 5: Report
 
 ### `/hq:archive`
 
-Input: none (operates on the current branch's task folder).
+Input: optional positional argument `cancel`. Empty → **done mode** (default). `cancel` → **cancel mode**. Any other value → ABORT with usage.
 
 ```
+Phase 0: Parse mode
+│  $ARGUMENTS empty   → done
+│  $ARGUMENTS=cancel  → cancel
+│  else               → ABORT
+│
 Phase 1: Resolve focus
 │  Read .hq/tasks/<branch-dir>/context.md (current branch)
 │  (missing → ABORT)
 │
 Phase 2: Pre-check PR
 │  gh pr list --head <branch> --state all
-│  MERGED → proceed
-│  OPEN / CLOSED / missing → ABORT with reason
+│  ┌────────────┬────────────────────────────┬───────────────────────────────────┐
+│  │ PR state   │ done mode                  │ cancel mode                       │
+│  ├────────────┼────────────────────────────┼───────────────────────────────────┤
+│  │ MERGED     │ proceed                    │ ABORT (use /hq:archive)           │
+│  │ OPEN       │ ABORT (wait for merge)     │ proceed (Phase 4 closes it)       │
+│  │ CLOSED     │ ABORT (suggest cancel arg) │ proceed (already closed)          │
+│  │ missing    │ ABORT (no PR yet)          │ proceed (no PR to close)          │
+│  └────────────┴────────────────────────────┴───────────────────────────────────┘
 │
 Phase 3: Pre-check FBs
 │  Any pending files in feedbacks/ (not done/)?
-│  yes → ABORT with list
-│  no  → proceed
+│  done   → yes → ABORT with list ; no → proceed
+│  cancel → record list (do NOT abort); travels with folder to cancel/
 │
-Phase 4: Archive
-│  mv .hq/tasks/<branch-dir> → .hq/tasks/done/<branch-dir>[-timestamp]
+Phase 4: Close PR + Issue        ← cancel mode only (done mode skips)
+│  if PR state was OPEN:
+│    gh pr close <n> --comment "..."          (no --delete-branch)
+│  gh issue close <plan> --reason "not planned" --comment "..."
+│  (parent hq:task is NOT touched)
 │
-Phase 5: Branch cleanup
+Phase 5: Archive folder
+│  done   → mv .hq/tasks/<branch-dir> → .hq/tasks/done/<branch-dir>[-timestamp]
+│  cancel → mv .hq/tasks/<branch-dir> → .hq/tasks/cancel/<branch-dir>[-timestamp]
+│
+Phase 6: Branch cleanup
 │  git checkout <base>
-│  git branch -d <feature>  (fallback -D on squash-merge)
+│  done   → git branch -d <feature> (fallback -D on squash-merge)
+│  cancel → git branch -D <feature> (unmerged by definition)
 │
-Phase 6: Memory
+Phase 7: Memory
 │  Clear focus entry
+│  done   → hq:plan was auto-closed by merge (Closes #<plan>)
+│  cancel → hq:plan was explicitly closed in Phase 4
 │
-Phase 7: Report
+Phase 8: Report  (mode-aware)
 ```
 
 **Key decisions**:
 
-- **No interactive confirmation** when pre-checks pass — archive and cleanup run unconditionally. If pre-checks fail, report what remains and stop; the user resolves manually.
-- **Never pushes / force-pushes** — all operations are local.
-- **No `hq:feedback` escalation** — pending FBs should never exist at archive time in a normal `/hq:start` flow; the check is defensive.
+- **Explicit `cancel` argument is the confirmation** — no additional interactive prompt. The strict argument parser (only empty or `cancel` accepted) catches typos.
+- **Mode-symmetric remote-branch policy** — neither mode deletes remote branches. `gh pr close` runs without `--delete-branch`; remote cleanup is left to repo settings / manual action.
+- **Cancel touches GitHub state**: closes the PR (if open) and explicitly closes the `hq:plan` Issue with reason `not planned`. The parent `hq:task` Issue is untouched — task-level requirements outlive a single canceled plan attempt.
+- **Folder structure is parallel**: `.hq/tasks/done/<branch-dir>/` and `.hq/tasks/cancel/<branch-dir>/` live side-by-side. `find-plan-branch.sh` scans only depth-2 `context.md` files, so archived contexts in either bucket do not collide with live contexts.
+- **Pending-FB handling diverges by mode**: done aborts (defensive — pending FBs are an abnormal post-`/hq:start` state); cancel records and proceeds (the FBs are part of the abandoned state and ride along to `cancel/` for the audit trail).
+- **Never pushes / force-pushes** — all git operations are local.
+- **No `hq:feedback` escalation** — escalation lives in `/hq:triage` during PR review, before merge.
 
 ### `/hq:respond`
 

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -426,7 +426,7 @@ gh:
 
 - **On start** (`/hq:start`): write `.hq/tasks/<branch-dir>/context.md`. Save focus info to your memory (project type) — include the branch name and plan number, and the source number when the plan has a parent `hq:task` (omit source otherwise).
 - **On status query**: read `.hq/tasks/<branch-dir>/context.md` → read the plan body from `.hq/tasks/<branch-dir>/gh/plan.md`. If cache not found, fall back to `gh issue view <plan> --json body --jq '.body'` → report status.
-- **On completion**: when a PR is created and all Plan items + Acceptance `[auto]` items are checked, update your memory to indicate no active task. The PR's `Closes #<plan>` handles issue closure on merge. The `context.md` file is left in place — it travels with the task folder until `/hq:archive` moves it to either `.hq/tasks/done/` (PR merged) or `.hq/tasks/cancel/` (PR closed without merging, via `/hq:archive cancel`).
+- **On completion**: when a PR is created and all Plan items + Acceptance `[auto]` items are checked, update your memory to indicate no active task. The PR's `Closes #<plan>` handles issue closure on merge. The `context.md` file is left in place — it travels with the task folder until `/hq:archive` moves it to either `.hq/tasks/done/` (PR merged) or `.hq/tasks/canceled/` (PR closed without merging, via `/hq:archive cancel`).
 
 ### Focus Resolution
 

--- a/plugin/v2/rules/workflow.md
+++ b/plugin/v2/rules/workflow.md
@@ -426,7 +426,7 @@ gh:
 
 - **On start** (`/hq:start`): write `.hq/tasks/<branch-dir>/context.md`. Save focus info to your memory (project type) — include the branch name and plan number, and the source number when the plan has a parent `hq:task` (omit source otherwise).
 - **On status query**: read `.hq/tasks/<branch-dir>/context.md` → read the plan body from `.hq/tasks/<branch-dir>/gh/plan.md`. If cache not found, fall back to `gh issue view <plan> --json body --jq '.body'` → report status.
-- **On completion**: when a PR is created and all Plan items + Acceptance `[auto]` items are checked, update your memory to indicate no active task. The PR's `Closes #<plan>` handles issue closure on merge. The `context.md` file is left in place — it travels with the task folder until `/hq:archive` moves it.
+- **On completion**: when a PR is created and all Plan items + Acceptance `[auto]` items are checked, update your memory to indicate no active task. The PR's `Closes #<plan>` handles issue closure on merge. The `context.md` file is left in place — it travels with the task folder until `/hq:archive` moves it to either `.hq/tasks/done/` (PR merged) or `.hq/tasks/cancel/` (PR closed without merging, via `/hq:archive cancel`).
 
 ### Focus Resolution
 


### PR DESCRIPTION
## Summary

`/hq:archive` に **cancel モード** を追加し、マージせずにクローズする PR を安全に archive できるようにする。

| Mode | Trigger | PR 状態 | 移動先 | hq:plan Issue クローズ |
|---|---|---|---|---|
| done (既存) | `/hq:archive` | MERGED 必須 | `.hq/tasks/done/` | PR merge の `Closes #<plan>` で自動 |
| cancel (新規) | `/hq:archive cancel` | OPEN / CLOSED / 無 | `.hq/tasks/canceled/` | `gh issue close --reason "not planned"` で明示 |

### Cancel モードの動作

- PR が **OPEN** なら `gh pr close <n>` で閉じる（`--delete-branch` は付けない — done モードと対称）
- PR が **CLOSED**（未マージ） / **無** なら GitHub 側操作はスキップ
- PR が **MERGED** なら **abort** — `/hq:archive`（plain）を案内（誤用防止）
- `hq:plan` Issue を `--reason "not planned"` で明示クローズ（PR merge が無いので `Closes #N` が効かないため）
- 親 `hq:task` Issue は触らない — task レベルの要件は単一プランの頓挫で消えない
- pending FB は abort せず記録して `.hq/tasks/canceled/<branch-dir>/feedbacks/` に同梱（audit trail）
- ローカル feature ブランチは `git branch -D` で強制削除（unmerged by definition）

### 設計判断

- **明示的な `cancel` 引数自体が confirmation** — 追加の対話確認なし。strict argument parser（`""` か `cancel` のみ受理）で typo を弾く
- **モード対称な remote-branch 不干渉ポリシー** — どちらも remote branch は削除しない
- **フォルダ名は `done/` と文法的に対称な過去分詞形 `canceled/`**（モード名/引数は短く `cancel` のまま）
- **`find-plan-branch.sh` は depth-2 の `context.md` のみスキャン** なので `done/` `canceled/` 配下の archived context は live と衝突せず、スクリプト変更不要

## Changes

| File | Why |
|---|---|
| `plugin/v2/commands/archive.md` | 仕様全面改訂。Phase 0 argument parsing 追加、Phase 2 PR state マトリクス、Phase 4 (Close PR + Issue, cancel only) 追加、Rules セクション更新 |
| `plugin/v2/docs/workflow.md` | Command Map 図とライフサイクル説明、`/hq:archive` 節を双モード対応に更新 |
| `plugin/v2/rules/workflow.md` | Focus lifecycle の "On completion" 行に canceled 行き先を追記（1 行） |
| `README.md` | 図と archive コマンドの description 行を更新 |

## Test plan

- [ ] `/hq:archive` (no args) が done モードで従来通り動作する（PR=MERGED で archive 成功 / 非 MERGED で abort）
- [ ] `/hq:archive cancel` が PR=OPEN を `gh pr close` で閉じ、`hq:plan` を `not planned` で閉じ、`.hq/tasks/canceled/` に移動し、ローカル feature ブランチを `-D` で削除する
- [ ] `/hq:archive cancel` が PR=CLOSED（未マージ）の状態でも、PR は既存のまま `hq:plan` 明示クローズ + `canceled/` 移動 + ブランチ削除を実行する
- [ ] `/hq:archive cancel` が PR=MERGED で abort し、plain `/hq:archive` を案内する
- [ ] `/hq:archive cancel` が PR 未作成の branch でも proceed する（hq:plan 明示クローズ + `canceled/` 移動 + ブランチ削除）
- [ ] `/hq:archive foo`（不正引数）が usage を表示して abort する
- [ ] pending FB が残っている状態で `/hq:archive` は abort、`/hq:archive cancel` は記録して proceed する
- [ ] `canceled/` 配下に同名 branch-dir が既にある場合、timestamp suffix で衝突回避される
- [ ] 親 `hq:task` Issue は cancel モード後もクローズされず残る